### PR TITLE
Bugfixes and improved robustness.

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -1585,7 +1585,7 @@ int eblob_plain_write(struct eblob_backend *b, struct eblob_key *key, void *data
 	}
 
 	/* do not calculate partial csum */
-	wc.flags = BLOB_DISK_CTL_NOCSUM;
+	wc.flags |= BLOB_DISK_CTL_NOCSUM;
 	err = eblob_write_commit_nolock(b, key, NULL, 0, &wc);
 	if (err)
 		goto err_out_exit;


### PR DESCRIPTION
- Do not overwrite USR1 flag in eblob_plain_write()  
  This fixes elliptics `ERANGE` errors.
- Add sanity check for eblob_write_commit()  
  This prevents segfault if garbage passed in `size` argument.
