### PR TITLE
examples: merge: skip broken entries

### DIFF
--- a/example/merge.cpp
+++ b/example/merge.cpp
@@ -258,6 +258,7 @@ int main(int argc, char *argv[])
 			if (memcmp(&ddc, &c.dc, sizeof(eblob_disk_control)) != 0) {
 				std::cout << "ERROR: data and index header mismatch" << std::endl;
 				broken++;
+				continue;
 			}
 
 			if (ddc.flags & BLOB_DISK_CTL_REMOVE) {


### PR DESCRIPTION
- Turn on strongest consistency check by default:  
  Data header should always be equal to index header - If this invariant is not true index file should be regenerated.
