### PR TITLE
blob: added sanity to record copy

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -1279,6 +1279,16 @@ static int eblob_write_prepare_disk_ll(struct eblob_backend *b, struct eblob_key
 			eblob_dump_wc(b, key, wc, "copy: ERROR-pread-data", err);
 			goto err_out_rollback;
 		}
+
+		/* Sanity: Check that on-disk and in-memory keys are the same */
+		if (memcmp(&old_dc.key, key, sizeof(struct eblob_key)) != 0) {
+			EBLOB_WARNX(b->cfg.log, EBLOB_LOG_ERROR,
+					"keys mismatch: in-memory: %s, on-disk: %s",
+					eblob_dump_id_len(key->id, EBLOB_ID_SIZE),
+					eblob_dump_id_len(old_dc.key.id, EBLOB_ID_SIZE));
+			goto err_out_rollback;
+		}
+
 		eblob_convert_disk_control(&old_dc);
 		size = old_dc.disk_size - sizeof(struct eblob_disk_control);
 


### PR DESCRIPTION
We should not blindly use `old_dc` data otherwise if blob is damaged we
may get garbage in `size` variable and run out of space on fs.

We also don't want to check it on startup because checking datafile
along with index will take too long.
