### PR TITLE
Corrupted blob handling bugfixes.

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -281,9 +281,8 @@ static int eblob_check_disk_one(struct eblob_iterate_local *loc)
 	err = eblob_check_record(bc, dc);
 	if (err != 0) {
 		eblob_log(ctl->log, EBLOB_LOG_ERROR,
-				"blob: eblob_check_record: skipping: offset: %llu\n",
+				"blob: eblob_check_record: offset: %llu\n",
 				loc->index_offset);
-		err = 1;
 		goto err_out_exit;
 	}
 


### PR DESCRIPTION
- Re-introduced hack for handling zero-sized entries as explained in e731ff2.
- Do not ignore corrupted entries on iteration because this behavior prevents eblob self-healing to kick in and "fix" corrupted index;  Also those corrupted entries then go to sorted index that can prevent blob from starting up next time.
  Currently "fix" means simple `ftruncate(2)` of index file to the last non-corrupted entry. See: http://doc.reverbrain.com/roadmap:eblob
