### PR TITLE
data-sort: add time-scheduled data-sort

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 
@@ -1161,7 +1162,7 @@ static int eblob_write_prepare_disk_ll(struct eblob_backend *b, struct eblob_key
 			goto err_out_exit;
 
 		if (ctl->sort.fd < 0)
-			datasort_schedule_sort(ctl);
+			datasort_force_sort(b);
 
 		ctl = list_last_entry(&b->bases, struct eblob_base_ctl, base_entry);
 	}
@@ -2349,6 +2350,9 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 
 	eblob_log(c->log, EBLOB_LOG_ERROR, "blob: start\n");
 
+	/* Init random number generator */
+	srandom(time(NULL));
+
 	b = calloc(1, sizeof(struct eblob_backend));
 	if (!b) {
 		errno = -ENOMEM;
@@ -2386,6 +2390,11 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 		c->defrag_timeout = EBLOB_DEFAULT_DEFRAG_TIMEOUT;
 	if (!c->defrag_percentage || (c->defrag_percentage < 0) || (c->defrag_percentage > 100))
 		c->defrag_percentage = EBLOB_DEFAULT_DEFRAG_PERCENTAGE;
+	if ((c->defrag_time < 0 || c->defrag_time > 24)
+			|| (c->defrag_splay < 0 || c->defrag_time > 24)) {
+		c->defrag_time = EBLOB_DEFAULT_DEFRAG_TIME;
+		c->defrag_splay = EBLOB_DEFAULT_DEFRAG_SPLAY;
+	}
 
 	memcpy(&b->cfg, c, sizeof(struct eblob_config));
 

--- a/library/blob.h
+++ b/library/blob.h
@@ -67,8 +67,11 @@
 #define EBLOB_BLOB_INDEX_SUFFIX			".index"
 #define EBLOB_BLOB_DEFAULT_BLOB_SIZE		(50 * EBLOB_1_G)
 #define EBLOB_BLOB_DEFAULT_RECORDS_IN_BLOB	(50000000)
-#define EBLOB_DEFAULT_DEFRAG_TIMEOUT		(-1)
+#define EBLOB_DEFAULT_DEFRAG_TIMEOUT		(86400)
 #define EBLOB_DEFAULT_DEFRAG_PERCENTAGE		(25)
+#define EBLOB_DEFAULT_DEFRAG_TIME		(3)
+#define EBLOB_DEFAULT_DEFRAG_SPLAY		(3)
+#define EBLOB_DEFAULT_DEFRAG_MIN_TIMEOUT	(60)
 #define EBLOB_DEFAULT_ITERATE_THREADS		(1)
 
 /* Size of one entry in cache */
@@ -502,6 +505,10 @@ int eblob_mutex_init(pthread_mutex_t *mutex);
 
 struct eblob_base_ctl *eblob_base_ctl_new(struct eblob_backend *b, int index,
 		const char *name, int name_len);
+
+/* Min/Max macros */
+#define EBLOB_MIN(a,b) ((a) < (b) ? (a) : (b))
+#define EBLOB_MAX(a,b) ((a) > (b) ? (a) : (b))
 
 /* Logging helpers */
 #define EBLOB_WARNX(log, severity, fmt, ...)	eblob_log(log, severity, \

--- a/library/datasort.h
+++ b/library/datasort.h
@@ -92,11 +92,22 @@ struct datasort_cfg {
 	struct eblob_base_ctl		*sorted_bctl;
 };
 
+/*
+ * Main data-sort routine
+ * NB! This is legacy name to match with eblob_generate_sorted_index
+ */
 int eblob_generate_sorted_data(struct datasort_cfg *dcfg);
+
+/* Removes left-overs from previous (failed) data-sort */
 int datasort_cleanup_stale(struct eblob_log *log, char *base, char *dir);
 
+/* Is base sorted or not? */
 int datasort_base_is_sorted(struct eblob_base_ctl *bctl);
-int datasort_schedule_sort(struct eblob_base_ctl *bctl);
+
+/* Forces data-sort to process as soon as possible */
+int datasort_force_sort(struct eblob_backend *b);
+/* Returns number of seconds till next defrag */
+uint64_t datasort_next_defrag(const struct eblob_backend *b);
 
 /*
  * Tiny binlog replacement.

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -221,17 +221,12 @@ err_out_exit:
 void *eblob_defrag(void *data)
 {
 	struct eblob_backend *b = data;
-	unsigned int sleep_time;
+	uint64_t sleep_time;
 
 	if (b == NULL)
 		return NULL;
 
-	/* If auto-sort is disabled - disable timer data-sort */
-	if (!(b->cfg.blob_flags & EBLOB_AUTO_DATASORT))
-		b->cfg.defrag_timeout = -1;
-
-	sleep_time = b->cfg.defrag_timeout;
-
+	sleep_time = datasort_next_defrag(b);
 	while (!b->need_exit) {
 		if ((sleep_time-- != 0) && (b->want_defrag == 0)) {
 			sleep(1);
@@ -240,7 +235,7 @@ void *eblob_defrag(void *data)
 
 		eblob_defrag_raw(b);
 		b->want_defrag = 0;
-		sleep_time = b->cfg.defrag_timeout;
+		sleep_time = datasort_next_defrag(b);
 	}
 
 	return NULL;

--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -30,7 +30,7 @@ class eblob_test {
 			cfg.sync = 30;
 			cfg.defrag_timeout = 20;
 			cfg.blob_size = 1024 * 1024 * 1024;
-			cfg.blob_flags = EBLOB_AUTO_DATASORT;
+			cfg.blob_flags = EBLOB_TIMED_DATASORT;
 			cfg.records_in_blob = m_iterations / 4;
 			cfg.log = m_logger->log();
 			cfg.file = (char *)path.c_str();

--- a/tests/stress/stress.c
+++ b/tests/stress/stress.c
@@ -578,6 +578,8 @@ main(int argc, char **argv)
 	bcfg.blob_flags = cfg.blob_flags;
 	bcfg.blob_size = cfg.blob_size;
 	bcfg.defrag_timeout = cfg.blob_defrag;
+	bcfg.defrag_time = DEFAULT_BLOB_DEFRAG_TIME;
+	bcfg.defrag_splay = DEFAULT_BLOB_DEFRAG_SPLAY;
 	bcfg.file = blob_path;
 	bcfg.iterate_threads = cfg.blob_threads;
 	bcfg.log = &logger;

--- a/tests/stress/stress.h
+++ b/tests/stress/stress.h
@@ -111,6 +111,8 @@ struct test_thread_cfg {
  */
 #define DEFAULT_BLOB_FLAGS		(0)
 #define DEFAULT_BLOB_DEFRAG		(10)
+#define DEFAULT_BLOB_DEFRAG_TIME	(4)
+#define DEFAULT_BLOB_DEFRAG_SPLAY	(5)
 #define DEFAULT_BLOB_RECORDS		(10000)
 #define DEFAULT_BLOB_SIZE		(100 * 1<<20)
 #define DEFAULT_BLOB_SYNC		(-1)


### PR DESCRIPTION
This will explicitly defines 3 data-sort modes:
- EBLOB_AUTO_DATASORT
  Sort bases on start + as they are closed.
- EBLOB_TIMED_DATASORT
  Sort bases each defrag_timeout seconds.
- EBLOB_SCHEDULED_DATASORT
  Sort bases in random interval defrag_time +- defrag_splay.
