### PR TITLE
Removed index_offset in eblob_base_ctl, replaced its use by index_size.

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -149,7 +149,7 @@ struct eblob_base_ctl {
 	pthread_mutex_t		lock;
 	pthread_cond_t		critness_wait;
 	int			data_fd, index_fd;
-	off_t			data_offset, index_offset;
+	off_t			data_offset;
 
 	void			*data;
 	unsigned long long	data_size;

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -1088,7 +1088,6 @@ static int datasort_swap_memory(struct datasort_cfg *dcfg)
 	assert(sorted_bctl->index_size == index.size);
 
 	sorted_bctl->data_offset = sorted_bctl->data_size;
-	sorted_bctl->index_offset = sorted_bctl->index_size;
 
 	/* Populate sorted index blocks */
 	if ((err = eblob_index_blocks_fill(sorted_bctl)) != 0) {

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -63,7 +63,7 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 
         /* Sanity: Do not remove seem-to-be empty blob if offsets are non-zero */
         if (((removed == 0) && (total == 0)) &&
-                        ((bctl->data_offset != 0) || (bctl->index_offset != 0)))
+            ((bctl->data_offset != 0) || (bctl->index_size != 0)))
                 return -EINVAL;
 
 	if (total < removed)
@@ -87,13 +87,13 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 		 * size of removed entries
 		 */
 		int64_t removed_size = removed * sizeof(struct eblob_disk_control);
-		if (bctl->index_offset != removed_size) {
+		if (bctl->index_size != removed_size) {
 			eblob_log(b->cfg.log, EBLOB_LOG_ERROR,
 					"%s: FAILED: trying to remove non empty blob: "
 					"removed: %" PRIu64 ", total: %" PRIu64
-					"index_offset: %" PRIu64 ", removed_size: %" PRIu64 "\n",
+					"index_size: %" PRIu64 ", removed_size: %" PRIu64 "\n",
 					__func__, removed, total,
-					bctl->index_offset, removed_size);
+					bctl->index_size, removed_size);
 			err = EBLOB_DEFRAG_NEEDED;
 		} else {
 			err = EBLOB_REMOVE_NEEDED;

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -118,7 +118,7 @@ int _eblob_base_ctl_cleanup(struct eblob_base_ctl *ctl)
 	eblob_data_unmap(&ctl->sort);
 
 	ctl->data_size = ctl->data_offset = 0;
-	ctl->index_size = ctl->index_offset = 0;
+	ctl->index_size = 0;
 
 	if (ctl->sort.fd >= 0)
 		close(ctl->sort.fd);


### PR DESCRIPTION
In most cases `index_offset` was equal to `index_size` and defined where new record should be written. Only case when `index_offset` wasn't equal to `index_size` was `index_offset` of closed blob. It was equal to 0. This situation had made confusion, so it was decided to remove `index_offset`.
Also there was satisfied TODO comment and used `__eblob_read_ll()` instead of `pread()`.
