### PR TITLE
Removed multithreading at blobs iterations.

### DIFF
--- a/bindings/cpp/eblob.cpp
+++ b/bindings/cpp/eblob.cpp
@@ -30,7 +30,6 @@ eblob::eblob(const char *log_file, const int log_level, const std::string &eblob
 	memset(&cfg, 0, sizeof(cfg));
 	cfg.file = (char *)eblob_path.c_str();
 	cfg.log = logger_.log();
-	cfg.iterate_threads = 16;
 	cfg.sync = 30;
 
 	eblob_ = eblob_init(&cfg);
@@ -273,7 +272,6 @@ void eblob::iterate(const struct eblob_iterate_callbacks *callbacks, unsigned in
 
 	ctl.b = eblob_;
 	ctl.log = logger_.log();
-	ctl.thread_num = callbacks->thread_num;
 	ctl.flags = flags;
 	ctl.iterator_cb = *callbacks;
 	ctl.priv = priv;

--- a/bindings/python/eblob_python.cpp
+++ b/bindings/python/eblob_python.cpp
@@ -121,7 +121,6 @@ public:
 		memset(&cb, 0, sizeof(struct eblob_iterate_callbacks));
 
 		cb.iterator = &eblob_py_iterator::iterator;
-		cb.thread_num = 1;
 
 		Py_BEGIN_ALLOW_THREADS
 		eblob::iterate(&cb, 0, reinterpret_cast<void *>(&it));
@@ -146,7 +145,6 @@ BOOST_PYTHON_MODULE(libeblob_python) {
 		.def_readwrite("blob_flags", &eblob_config::blob_flags)
 		.def_readwrite("sync", &eblob_config::sync)
 		.def_readwrite("file", &eblob_config::file)
-		.def_readwrite("iterate_threads", &eblob_config::iterate_threads)
 		.def_readwrite("blob_size", &eblob_config::blob_size)
 		.def_readwrite("records_in_blob", &eblob_config::records_in_blob)
 	;

--- a/doc/README
+++ b/doc/README
@@ -59,10 +59,8 @@ struct eblob_config {
 	 */
 	char			*file;
 
-	/* number of threads which will iterate over
-	 * each blob file at startup
-	 */
-	int			iterate_threads;
+	/* for future use */
+	int				reserved;
 
 	/* maximum blob size (supported modifiers: G, M, K)
 	 * when blob file size becomes bigger than this value

--- a/example/iterate_send.cpp
+++ b/example/iterate_send.cpp
@@ -347,7 +347,6 @@ int main(int argc, char *argv[])
 	int ch;
 	int index_start = 0;
 	int index_max = INT_MAX;
-	int thread_num = 16;
 	std::string base("/opt/elliptics/data-");
 	char *addr = (char *)"localhost";
 	int port = 1025;
@@ -366,9 +365,6 @@ int main(int argc, char *argv[])
 				break;
 			case 'I':
 				index_max = atoi(optarg);
-				break;
-			case 't':
-				thread_num = atoi(optarg);
 				break;
 			case 'g':
 				group = atoi(optarg);
@@ -394,10 +390,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	isend is(group, addr, port, thread_num, write, log_mask, wait_timeout);
+	isend is(group, addr, port, write, log_mask, wait_timeout);
 	eblob_iterator it(base);
 
-	it.iterate(is, thread_num, index_start, index_max);
+	it.iterate(is, index_start, index_max);
 
 	is.need_exit = true;
 }

--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -290,11 +290,8 @@ struct eblob_config {
 	 */
 	char			*file;
 
-	/* number of threads which will iterate over
-	 * each blob file at startup
-	 * Default: 1
-	 */
-	int			iterate_threads;
+	/* for future use */
+	int				reserved;
 
 	/* maximum blob size
 	 * when blob file size becomes bigger than this value
@@ -401,9 +398,8 @@ struct eblob_iterate_callbacks {
 	 */
 	int				(* iterator_free)(struct eblob_iterate_control *ctl, void **thread_priv);
 
-	/* Number of iterator threads. If this value is not 0 it will override default from config */
-	int				thread_num;
-
+	/* for future use */
+	int				reserved;
 };
 
 #define EBLOB_ITERATE_FLAGS_ALL			(1<<0)	/* iterate over all blobs, not only the last one */
@@ -418,7 +414,9 @@ struct eblob_iterate_control {
 
 	struct eblob_base_ctl		*base;
 
-	int				thread_num;
+	/* for future use */
+	int				reserved;
+
 	int				err;
 
 	unsigned int			flags;

--- a/library/blob.c
+++ b/library/blob.c
@@ -525,17 +525,16 @@ static int eblob_check_disk(struct eblob_iterate_local *loc)
 /**
  * eblob_blob_iterator() - one iterator thread.
  *
- * Splits data into `local_max_num' chunks and passes them to
+ * Splits data into `batch_size' chunks and passes them to
  * eblob_check_disk()
  */
-static void *eblob_blob_iterator(void *data)
+int eblob_blob_iterator(struct eblob_iterate_priv *iter_priv)
 {
-	struct eblob_iterate_priv *iter_priv = data;
 	struct eblob_iterate_control *ctl = iter_priv->ctl;
 	struct eblob_base_ctl *bc = ctl->base;
 
-	int local_max_num = 1024;
-	struct eblob_disk_control dc[local_max_num];
+	int batch_size = 1024;
+	struct eblob_disk_control dc[batch_size];
 	struct eblob_iterate_local loc;
 	int err = 0;
 	/*
@@ -543,54 +542,45 @@ static void *eblob_blob_iterator(void *data)
 	 * in it is identical to order of records in data blob.
 	 */
 	int index_fd = eblob_get_index_fd(bc);
-	static int hdr_size = sizeof(struct eblob_disk_control);
+	static const int hdr_size = sizeof(struct eblob_disk_control);
 
 	memset(&loc, 0, sizeof(loc));
 
 	loc.iter_priv = iter_priv;
 
-	while (ACCESS_ONCE(ctl->thread_num) > 0) {
-		/* Wait until all pending writes are finished and lock */
-		pthread_mutex_lock(&bc->lock);
-
-		if (ACCESS_ONCE(ctl->thread_num) == 0) {
-			err = 0;
-			goto err_out_unlock;
-		}
-
-		/*if index after index_offset has less then local_max_num eblob_disk_controls
+	for (; ctl->index_offset < ctl->index_size; ctl->index_offset += batch_size * hdr_size) {
+		/*if index after index_offset has less then batch_size eblob_disk_controls
 		* then read only available ones.
 		*/
-		if (ctl->index_offset + hdr_size * local_max_num > ctl->index_size){
-			local_max_num = (ctl->index_size - ctl->index_offset) / hdr_size;
-			if (local_max_num == 0) {
+		if (ctl->index_offset + batch_size * hdr_size > ctl->index_size){
+			batch_size = (ctl->index_size - ctl->index_offset) / hdr_size;
+			if (batch_size == 0) {
 				err = 0;
 				goto err_out_unlock;
 			}
 		}
 
-		err = __eblob_read_ll(index_fd, dc, hdr_size * local_max_num, ctl->index_offset);
+		/* Wait until all pending writes are finished and lock */
+		pthread_mutex_lock(&bc->lock);
+		err = __eblob_read_ll(index_fd, dc, batch_size * hdr_size, ctl->index_offset);
 		if (err)
 			goto err_out_unlock;
+		pthread_mutex_unlock(&bc->lock);
 
-		if (ctl->index_offset + local_max_num * hdr_size > ctl->index_size) {
+		if (ctl->index_offset + batch_size * hdr_size > ctl->index_size) {
 			eblob_log(ctl->log, EBLOB_LOG_ERROR, "blob: index grew under us, iteration stops: "
-					"index_offset: %llu, index_size: %llu, eblob_data_size: %llu, local_max_num: %d, "
-					"index_offset+local_max_num: %llu, but wanted less than index_size.\n",
-					ctl->index_offset, ctl->index_size, ctl->data_size, local_max_num,
-					ctl->index_offset + local_max_num * hdr_size);
+					"index_offset: %llu, index_size: %llu, eblob_data_size: %llu, batch_size: %d, "
+					"index_offset+batch_size: %llu, but wanted less than index_size.\n",
+					ctl->index_offset, ctl->index_size, ctl->data_size, batch_size,
+					ctl->index_offset + batch_size * hdr_size);
 			err = 0;
 			goto err_out_unlock;
 		}
 
 		loc.index_offset = ctl->index_offset;
-
-		ctl->index_offset += hdr_size * local_max_num;
-		pthread_mutex_unlock(&bc->lock);
-
 		loc.dc = dc;
 		loc.pos = 0;
-		loc.num = local_max_num;
+		loc.num = batch_size;
 
 		/*
 		 * Hold btcl for duration of one batch - thus nobody can
@@ -608,10 +598,6 @@ static void *eblob_blob_iterator(void *data)
 err_out_unlock:
 	pthread_mutex_unlock(&bc->lock);
 err_out_check:
-	/*
-	 * Returning error from iterator callback is dangerous - iterator stops
-	 */
-	ctl->thread_num = 0;
 
 	eblob_log(ctl->log, EBLOB_LOG_INFO, "blob-0.%d: iterated: data_fd: %d, index_fd: %d, "
 			"data_size: %llu, index_offset: %llu\n",
@@ -674,7 +660,7 @@ err_out_check:
 	if (ctl->err == 0 && err != 0)
 		ctl->err = err;
 
-	return NULL;
+	return err;
 }
 
 /**
@@ -683,10 +669,8 @@ err_out_check:
  */
 int eblob_blob_iterate(struct eblob_iterate_control *ctl)
 {
-	int i, err, thread_num = ctl->thread_num;
-	int created = 0, inited = 0;
-	pthread_t tid[ctl->thread_num];
-	struct eblob_iterate_priv iter_priv[ctl->thread_num];
+	int err;
+	struct eblob_iterate_priv iter_priv;
 
 	/* Wait until nobody uses bctl->data */
 	eblob_base_wait_locked(ctl->base);
@@ -702,36 +686,27 @@ int eblob_blob_iterate(struct eblob_iterate_control *ctl)
 	ctl->index_size = ctl->base->index_size;
 	pthread_mutex_unlock(&ctl->base->lock);
 
-	for (i = 0; i < thread_num; ++i) {
-		iter_priv[i].ctl = ctl;
-		iter_priv[i].thread_priv = NULL;
+	iter_priv.ctl = ctl;
+	iter_priv.thread_priv = NULL;
 
-		if (ctl->iterator_cb.iterator_init) {
-			err = ctl->iterator_cb.iterator_init(ctl, &iter_priv[i].thread_priv);
-			if (err) {
-				ctl->err = err;
-				eblob_log(ctl->log, EBLOB_LOG_ERROR, "blob: failed to init iterator: %d.\n", err);
-				break;
-			}
-			inited++;
-		}
-
-		err = pthread_create(&tid[i], NULL, eblob_blob_iterator, &iter_priv[i]);
+	if (ctl->iterator_cb.iterator_init) {
+		err = ctl->iterator_cb.iterator_init(ctl, &iter_priv.thread_priv);
 		if (err) {
 			ctl->err = err;
-			eblob_log(ctl->log, EBLOB_LOG_ERROR, "blob: failed to create iterator thread: %d.\n", err);
-			break;
+			eblob_log(ctl->log, EBLOB_LOG_ERROR, "blob: failed to init iterator: %d.\n", err);
+			goto err_out_exit;
 		}
-		created++;
 	}
 
-	for (i = 0; i < created; ++i) {
-		pthread_join(tid[i], NULL);
+	err = eblob_blob_iterator(&iter_priv);
+	if (err) {
+		ctl->err = err;
+		eblob_log(ctl->log, EBLOB_LOG_ERROR, "blob: iterator failed: %d.\n", err);
+		goto err_out_exit;
 	}
 
-	for (i = 0; ctl->iterator_cb.iterator_free && i < inited; ++i) {
-		ctl->iterator_cb.iterator_free(ctl, &iter_priv[i].thread_priv);
-	}
+	if (ctl->iterator_cb.iterator_free)
+		ctl->iterator_cb.iterator_free(ctl, &iter_priv.thread_priv);
 
 	if ((ctl->err == -ENOENT) && eblob_total_elements(ctl->b))
 		ctl->err = 0;
@@ -2674,8 +2649,6 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 		c->index_block_bloom_length = EBLOB_INDEX_DEFAULT_BLOCK_BLOOM_LENGTH;
 	if (!c->blob_size)
 		c->blob_size = EBLOB_BLOB_DEFAULT_BLOB_SIZE;
-	if (!c->iterate_threads)
-		c->iterate_threads = EBLOB_DEFAULT_ITERATE_THREADS;
 	if (!c->records_in_blob)
 		c->records_in_blob = EBLOB_BLOB_DEFAULT_RECORDS_IN_BLOB;
 	if (!c->defrag_timeout)

--- a/library/blob.h
+++ b/library/blob.h
@@ -78,7 +78,6 @@
 #define EBLOB_DEFAULT_DEFRAG_TIME		(3)
 #define EBLOB_DEFAULT_DEFRAG_SPLAY		(3)
 #define EBLOB_DEFAULT_DEFRAG_MIN_TIMEOUT	(60)
-#define EBLOB_DEFAULT_ITERATE_THREADS		(1)
 
 /* Size of one entry in cache */
 static const size_t EBLOB_HASH_ENTRY_SIZE = sizeof(struct eblob_ram_control)

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -542,7 +542,6 @@ static int datasort_split(struct datasort_cfg *dcfg)
 	assert(dcfg != NULL);
 	assert(dcfg->b != NULL);
 	assert(dcfg->bctl != NULL);
-	assert(dcfg->thread_num > 0);
 	assert(dcfg->bctl_cnt > 0);
 
 	/* Init iterator config */
@@ -554,14 +553,13 @@ static int datasort_split(struct datasort_cfg *dcfg)
 		ictl.b = dcfg->b;
 		ictl.base = dcfg->bctl[n];
 		ictl.log = dcfg->b->cfg.log;
-		ictl.thread_num = dcfg->thread_num;
 		ictl.flags = EBLOB_ITERATE_FLAGS_ALL | EBLOB_ITERATE_FLAGS_READONLY;
 		ictl.iterator_cb.iterator = datasort_split_iterator;
 		ictl.iterator_cb.iterator_init = datasort_split_iterator_init;
 		ictl.iterator_cb.iterator_free = datasort_split_iterator_free;
 
-		EBLOB_WARNX(dcfg->log, EBLOB_LOG_INFO, "defrag: split: start, name: %s, threads: %d",
-				ictl.base->name, ictl.thread_num);
+		EBLOB_WARNX(dcfg->log, EBLOB_LOG_INFO, "defrag: split: start, name: %s",
+				ictl.base->name);
 
 		/* Run iteration */
 		err = eblob_blob_iterate(&ictl);
@@ -1333,8 +1331,6 @@ int eblob_generate_sorted_data(struct datasort_cfg *dcfg)
 		EBLOB_WARNX(dcfg->log, EBLOB_LOG_NOTICE, "defrag: sorting: %s", dcfg->bctl[n]->name);
 
 	/* Setup defaults */
-	if (dcfg->thread_num == 0)
-		dcfg->thread_num = dcfg->b->cfg.iterate_threads;
 	if (dcfg->chunk_size == 0)
 		dcfg->chunk_size = EBLOB_DATASORT_DEFAULTS_CHUNK_SIZE;
 	if (dcfg->chunk_limit == 0)

--- a/library/datasort.h
+++ b/library/datasort.h
@@ -73,8 +73,6 @@ struct datasort_cfg {
 	uint64_t			chunk_size;
 	/* Limit on number of records in one chunk */
 	uint64_t			chunk_limit;
-	/* Split iterator threads */
-	unsigned int			thread_num;
 	/* Lock used by blob iterator */
 	pthread_mutex_t			lock;
 	/* Splitter chunks */

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -747,7 +747,7 @@ static int eblob_blob_iter(struct eblob_disk_control *dc, struct eblob_ram_contr
 
 static int eblob_iterate_existing(struct eblob_backend *b, struct eblob_iterate_control *ctl)
 {
-	int err, thread_num = ctl->thread_num, idx = 0;
+	int err, idx = 0;
 	struct eblob_base_ctl *bctl, *bctl_tmp;
 	int want;
 
@@ -756,12 +756,6 @@ static int eblob_iterate_existing(struct eblob_backend *b, struct eblob_iterate_
 
 	ctl->log = b->cfg.log;
 	ctl->b = b;
-
-	if (!thread_num)
-		thread_num = b->cfg.iterate_threads;
-
-	if (ctl->iterator_cb.thread_num)
-		thread_num = ctl->iterator_cb.thread_num;
 
 	if (ctl->flags & EBLOB_ITERATE_FLAGS_INITIAL_LOAD) {
 		err = eblob_scan_base(b);
@@ -777,7 +771,6 @@ static int eblob_iterate_existing(struct eblob_backend *b, struct eblob_iterate_
 		if (!ctl->blob_num ||
 				((idx >= ctl->blob_start) && (idx < ctl->blob_num - ctl->blob_start))) {
 			ctl->base = bctl;
-			ctl->thread_num = thread_num;
 
 			err = 0;
 			if (bctl->sort.fd < 0 || (ctl->flags & EBLOB_ITERATE_FLAGS_ALL)) {

--- a/tests/stress/options.c
+++ b/tests/stress/options.c
@@ -89,7 +89,6 @@ options_set_defaults(void)
 	cfg.blob_records = DEFAULT_BLOB_RECORDS;
 	cfg.blob_size = DEFAULT_BLOB_SIZE;
 	cfg.blob_sync = DEFAULT_BLOB_SYNC;
-	cfg.blob_threads = DEFAULT_BLOB_THREADS;
 	cfg.log_level = DEFAULT_LOG_LEVEL;
 	cfg.test_delay = DEFAULT_TEST_DELAY;
 	cfg.test_force_defrag = DEFAULT_TEST_FORCE_DEFRAG;
@@ -183,9 +182,6 @@ options_get(int argc, char **argv)
 		case 'S':
 			options_get_ll(&cfg.test_item_size, optarg);
 			break;
-		case 't':
-			options_get_l(&cfg.blob_threads, optarg);
-			break;
 		case 'T':
 			options_get_l(&cfg.test_threads, optarg);
 			break;
@@ -215,7 +211,6 @@ options_dump(void)
 	printf("Maximum number of records per base: %lld\n", cfg.blob_records);
 	printf("Maximum size of base in bytes: %lld\n", cfg.blob_size);
 	printf("sync(2) period in seconds: %ld\n", cfg.blob_sync);
-	printf("Number of iterator threads: %ld\n", cfg.blob_threads);
 	printf("Log level for eblog_log: %ld\n", cfg.log_level);
 	printf("Delay in milliseconds between iterations: %ld\n", cfg.test_delay);
 	printf("Force defrag after: %lld\n", cfg.test_force_defrag);

--- a/tests/stress/stress.c
+++ b/tests/stress/stress.c
@@ -586,7 +586,6 @@ main(int argc, char **argv)
 	bcfg.defrag_time = DEFAULT_BLOB_DEFRAG_TIME;
 	bcfg.defrag_splay = DEFAULT_BLOB_DEFRAG_SPLAY;
 	bcfg.file = blob_path;
-	bcfg.iterate_threads = cfg.blob_threads;
 	bcfg.log = &logger;
 	bcfg.records_in_blob = cfg.blob_records;
 	bcfg.sync = cfg.blob_sync;

--- a/tests/stress/stress.h
+++ b/tests/stress/stress.h
@@ -69,7 +69,6 @@ struct test_cfg {
 	long long	blob_records;		/* Number of records in base */
 	long long	blob_size;		/* Max size of base in bytes */
 	long		blob_sync;		/* sync(2) period in seconds */
-	long		blob_threads;		/* Number of iterator threads */
 	long		log_level;		/* Log level for eblog_log */
 	long		test_delay;		/* Delay in milliseconds between
 						   iterations */
@@ -121,7 +120,6 @@ struct test_thread_cfg {
 #define DEFAULT_BLOB_RECORDS		(10000)
 #define DEFAULT_BLOB_SIZE		(100 * 1<<20)
 #define DEFAULT_BLOB_SYNC		(-1)
-#define DEFAULT_BLOB_THREADS		(16)
 #define DEFAULT_LOG_LEVEL		(EBLOB_LOG_DEBUG + 1)
 #define DEFAULT_TEST_DELAY		(10)
 #define DEFAULT_TEST_FORCE_DEFRAG	(0)


### PR DESCRIPTION
There is no need to iterate blobs in multiple threads. Multiple threads were added for cases when iteration callback performs so slow operations, that is comparable with disk read. There are no such operations in our practice.
