### PR TITLE
New defragmentation state and increased verbosity of index lookup

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -181,8 +181,9 @@ enum eblob_defrag_type {
 	/* Defrag thresholds weren't met */
 	EBLOB_DEFRAG_NOT_NEEDED = 0,
 	/* Defrag needed */
-	EBLOB_DEFRAG_NEEDED,
-	EBLOB_REMOVE_NEEDED,
+	EBLOB_DEFRAG_NEEDED,	/* Entry should be defragmented */
+	EBLOB_REMOVE_NEEDED,	/* Entry could be removed */
+	EBLOB_MERGE_NEEDED		/* Entry could be merged into a biggest entry */
 };
 
 /*


### PR DESCRIPTION
Added new state of base - EBLOB_MERGE_NEEDED. This state means that blob is already defragmented but its size allow him to be merged with another one. Added skipping such blobs if there is no another blob with which it can be merged.
Increased verbosity of some logs inside eblob_disk_index_lookup.
