### PR TITLE
Indexsort

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -519,7 +519,7 @@ void eblob_base_remove(struct eblob_base_ctl *bctl);
  * Generates sorted index for the blob \a bctl
  * flushes keys from cache and fills index blocks
  */
-int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *bctl);
+int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *bctl, int init_load);
 
 int eblob_index_blocks_destroy(struct eblob_base_ctl *bctl);
 

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -267,7 +267,7 @@ int eblob_defrag(struct eblob_backend *b)
 				struct eblob_base_ctl * const bctl = bctls[previous];
 				/* If defrag started only for index sort - check that blob's index is unsorted. */
 				if (bctl->sort.fd < 0) {
-					if (err = eblob_generate_sorted_index(b, bctl))
+					if (err = eblob_generate_sorted_index(b, bctl, 0))
 						EBLOB_WARNC(b->cfg.log, -err, EBLOB_LOG_ERROR, "defrag: indexsort: FAILED");
 				}
 				break;

--- a/library/index.c
+++ b/library/index.c
@@ -535,7 +535,7 @@ static int indexsort_flush_cache(struct eblob_backend *b, struct eblob_map_fd *s
 	return 0;
 }
 
-int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *bctl) {
+int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *bctl, int init_load) {
 	struct eblob_map_fd src, dst;
 	int fd, err, len;
 	char *file, *dst_file;
@@ -617,12 +617,14 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 		goto err_out_unmap_src;
 	}
 
-	/* Capture all removed entries starting from that moment */
-	err = indexsort_binlog_start(b, bctl);
-	if (err != 0) {
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: indexsort_binlog_start: index: %d",
-				bctl->index);
-		goto err_out_unmap_dst;
+	if (!init_load) {
+		/* Capture all removed entries starting from that moment */
+		err = indexsort_binlog_start(b, bctl);
+		if (err != 0) {
+			EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: indexsort_binlog_start: index: %d",
+					bctl->index);
+			goto err_out_unmap_dst;
+		}
 	}
 
 	memcpy(dst.data, src.data, dst.size);
@@ -641,32 +643,35 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	pthread_mutex_lock(&b->lock);
 	/* Wait for pending writes to finish and lock bctl(s) */
 	eblob_base_wait_locked(bctl);
-	/* Lock hash - prevent using old offsets with new sorted index */
-	if ((err = pthread_rwlock_wrlock(&b->hash.root_lock)) != 0) {
-		err = -err;
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: pthread_rwlock_wrlock: index: %d: FAILED",
-				bctl->index);
-		goto err_unlock_bctl;
-	}
 
-	/* Apply binlog */
-	err = indexsort_binlog_apply(bctl, &dst);
-	if (err != 0) {
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: indexsort_binlog_apply: index: %d: FAILED",
-				bctl->index);
-		goto err_unlock_hash;
-	}
+	if (!init_load) {
+		/* Lock hash - prevent using old offsets with new sorted index */
+		if ((err = pthread_rwlock_wrlock(&b->hash.root_lock)) != 0) {
+			err = -err;
+			EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: pthread_rwlock_wrlock: index: %d: FAILED",
+					bctl->index);
+			goto err_unlock_bctl;
+		}
 
-	/*
-	 * Remove sorted index keys from cache
-	 *! This should be made before setting bctl->sort because l2hash reads data from index and
-	 *! uses eblob_get_index_fd for determining index_fd which will return bctl->sort if it is set.
-	 */
-	err = indexsort_flush_cache(b, &dst);
-	if (err) {
-		EBLOB_WARNC(b->cfg.log, -err, EBLOB_LOG_ERROR, "defrag: indexsort: indexsort_flush_cache: index: %d: FAILED",
-			bctl->index);
-		goto err_unlock_hash;
+		/* Apply binlog */
+		err = indexsort_binlog_apply(bctl, &dst);
+		if (err != 0) {
+			EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: indexsort_binlog_apply: index: %d: FAILED",
+					bctl->index);
+			goto err_unlock_hash;
+		}
+
+		/*
+		 * Remove sorted index keys from cache
+		 *! This should be made before setting bctl->sort because l2hash reads data from index and
+		 *! uses eblob_get_index_fd for determining index_fd which will return bctl->sort if it is set.
+		 */
+		err = indexsort_flush_cache(b, &dst);
+		if (err) {
+			EBLOB_WARNC(b->cfg.log, -err, EBLOB_LOG_ERROR, "defrag: indexsort: indexsort_flush_cache: index: %d: FAILED",
+				bctl->index);
+			goto err_unlock_hash;
+		}
 	}
 
 	bctl->sort = dst;
@@ -682,16 +687,18 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 
 	rename(file, dst_file);
 
-	/* Stop binlog */
-	err = eblob_binlog_stop(&bctl->binlog);
-	if (err != 0) {
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: eblob_binlog_stop: index: %d: FAILED",
-				bctl->index);
-		goto err_unlock_hash;
+	if (!init_load) {
+		/* Stop binlog */
+		err = eblob_binlog_stop(&bctl->binlog);
+		if (err != 0) {
+			EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: eblob_binlog_stop: index: %d: FAILED",
+					bctl->index);
+			goto err_unlock_hash;
+		}
+		/* Unlock */
+		pthread_rwlock_unlock(&b->hash.root_lock);
 	}
 
-	/* Unlock */
-	pthread_rwlock_unlock(&b->hash.root_lock);
 	pthread_mutex_unlock(&bctl->lock);
 	pthread_mutex_unlock(&b->lock);
 

--- a/library/index.c
+++ b/library/index.c
@@ -514,8 +514,6 @@ static int indexsort_flush_cache(struct eblob_backend *b, struct eblob_map_fd *s
 
 	for (offset = 0; offset < sorted->size; offset += hdr_size) {
 		struct eblob_disk_control *dc = sorted->data + offset;
-		eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "defrag: indexsort: removing key: %s from cache flags: %s\n",
-		          eblob_dump_id(dc->key.id), eblob_dump_dctl_flags(dc->flags));
 		/* This entry was removed in binlog_apply */
 		if (dc->flags & BLOB_DISK_CTL_REMOVE)
 			continue;

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -278,7 +278,7 @@ again:
 		if (ctl->index_size &&
 				((ctl->data_size >= b->cfg.blob_size) ||
 				(ctl->index_size / sizeof(struct eblob_disk_control) >= b->cfg.records_in_blob))) {
-			err = eblob_generate_sorted_index(b, ctl);
+			err = eblob_generate_sorted_index(b, ctl, 1);
 			if (err) {
 				eblob_log(b->cfg.log, EBLOB_LOG_ERROR,
 						"bctl: index: %d, eblob_generate_sorted_index: FAILED\n", ctl->index);
@@ -627,7 +627,7 @@ static int eblob_scan_base(struct eblob_backend *b)
 		/* Sort only nonempty and unsorted indexes */
 		if (bctl->index_size &&
 		    bctl->sort.fd < 0) {
-			eblob_generate_sorted_index(b, bctl);
+			eblob_generate_sorted_index(b, bctl, 1);
 		}
 	}
 


### PR DESCRIPTION
Using binlog and flushing cache is useless if index is sorting on init_load because at the moment no other action can use binlog or cache or write/read keys.