### PR TITLE
Exception instead of error code

### DIFF
--- a/bindings/cpp/eblob.cpp
+++ b/bindings/cpp/eblob.cpp
@@ -22,8 +22,18 @@
 
 using namespace ioremap::eblob;
 
-eblob::eblob(const char *log_file, const int log_level, const std::string &eblob_path) :
-	logger_(log_file, log_level)
+static eblob_backend *init_eblob(eblob_config *cfg) {
+	eblob_backend *ret = eblob_init(cfg);
+	if (!ret) {
+		std::ostringstream str;
+		str << "EBLOB: Failed to initialize eblob: " << strerror(-errno);
+		throw std::runtime_error(str.str());
+	}
+	return ret;
+}
+
+eblob::eblob(const char *log_file, const int log_level, const std::string &eblob_path)
+: logger_(log_file, log_level)
 {
 	struct eblob_config cfg;
 
@@ -32,30 +42,22 @@ eblob::eblob(const char *log_file, const int log_level, const std::string &eblob
 	cfg.log = logger_.log();
 	cfg.sync = 30;
 
-	eblob_ = eblob_init(&cfg);
-	if (!eblob_) {
-		throw std::runtime_error("Failed to initialize eblob");
-	}
+	eblob_ = init_eblob(&cfg);
 }
 
-eblob::eblob(struct eblob_config *cfg) : logger_("/dev/stdout", EBLOB_LOG_ERROR)
+eblob::eblob(struct eblob_config *cfg)
+: logger_("/dev/stdout", EBLOB_LOG_ERROR)
 {
 	if (!cfg->log)
 		cfg->log = logger_.log();
-	eblob_ = eblob_init(cfg);
-	if (!eblob_) {
-		throw std::runtime_error("Failed to initialize eblob");
-	}
+	eblob_ = init_eblob(cfg);
 }
 
-eblob::eblob(const char *log_file, const int log_level, struct eblob_config *cfg) :
-	logger_(log_file, log_level)
+eblob::eblob(const char *log_file, const int log_level, struct eblob_config *cfg)
+: logger_(log_file, log_level)
 {
 	cfg->log = logger_.log();
-	eblob_ = eblob_init(cfg);
-	if (!eblob_) {
-		throw std::runtime_error("Failed to initialize eblob");
-	}
+	eblob_ = init_eblob(cfg);
 }
 
 eblob::~eblob()
@@ -73,7 +75,8 @@ void eblob::write(const struct eblob_key &key, const void *data, const uint64_t 
 	int err = eblob_write(eblob_, (struct eblob_key *)&key, (void *)data, offset, dsize, flags);
 	if (err) {
 		std::ostringstream str;
-		str << "eblob write failed: dsize: " << dsize << ": " << strerror(-err);
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": eblob write failed: offset: "
+			<< offset << ", dsize: " << dsize << ", flags: " << flags << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 }
@@ -83,27 +86,25 @@ void eblob::write(const struct eblob_key &key, const std::string &data, const ui
 	write(key, data.data(), offset, data.size(), flags);
 }
 
-int eblob::read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size)
+void eblob::read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size)
 {
-	return read(key, fd, offset, size, EBLOB_READ_CSUM);
+	read(key, fd, offset, size, EBLOB_READ_CSUM);
 }
 
-int eblob::read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size,
-		enum eblob_read_flavour csum)
-{
+void eblob::read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size,
+		enum eblob_read_flavour csum) {
 	int err;
-
 	if (csum)
 		err = eblob_read(eblob_, (struct eblob_key *)&key, fd, offset, size);
 	else
 		err = eblob_read_nocsum(eblob_, (struct eblob_key *)&key, fd, offset, size);
-	if (err < 0) {
+
+	if (err) {
 		std::ostringstream str;
-		str << "eblob read failed: " << strerror(-err);
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": eblob read failed: offset: "
+			<< offset << ", size: " << size << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }
 
 std::string eblob::read(const struct eblob_key &key, const uint64_t req_offset, const uint64_t req_size)
@@ -126,7 +127,8 @@ std::string eblob::read(const struct eblob_key &key, const uint64_t req_offset,
 		err = eblob_read_data_nocsum(eblob_, (struct eblob_key *)&key, req_offset, &data, &dsize);
 	if (err < 0) {
 		std::ostringstream str;
-		str << "eblob read failed: " << strerror(-err);
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": eblob read failed: offset: "
+			<< req_offset << ", size: " << dsize << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 
@@ -179,7 +181,13 @@ std::string eblob::read_hashed(const std::string &key, const uint64_t offset, co
 
 void eblob::remove(const struct eblob_key &key)
 {
-	eblob_remove(eblob_, (struct eblob_key *)&key);
+	int err = eblob_remove(eblob_, (struct eblob_key *)&key);
+	if (err) {
+		std::ostringstream str;
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": eblob remove failed: "
+			<< strerror(-err);
+		throw std::runtime_error(str.str());
+	}
 }
 
 unsigned long long eblob::elements(void)
@@ -189,7 +197,13 @@ unsigned long long eblob::elements(void)
 
 void eblob::remove_hashed(const std::string &key)
 {
-	eblob_remove_hashed(eblob_, key.data(), key.size());
+	int err = eblob_remove_hashed(eblob_, key.data(), key.size());
+	if (err) {
+		std::ostringstream str;
+		str << "EBLOB: " << key << ": failed to remove hashed key, err: "
+			<< strerror(-err);
+		throw std::runtime_error(str.str());
+	}
 }
 
 void eblob::remove_blobs(void)
@@ -199,13 +213,11 @@ void eblob::remove_blobs(void)
 
 void eblob::truncate(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
 {
-	int err;
-
-	err = eblob_write_commit(eblob_, (struct eblob_key *)&key, size, flags);
+	int err = eblob_write_commit(eblob_, (struct eblob_key *)&key, size, flags);
 	if (err < 0) {
 		std::ostringstream str;
-		str << "EBLOB: " << eblob_dump_id(key.id) << ": failed to truncate/commit to " << size <<
-			", flags: " << flags << ", err: " << err;
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": failed to truncate/commit to "
+			<< size << ", flags: " << flags << ", err: " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 }
@@ -224,7 +236,7 @@ void eblob::start_defrag()
 	err = eblob_start_defrag(eblob_);
 	if (err) {
 		std::ostringstream str;
-		str << "EBLOB: failed to start defragmentation, err: " << err;
+		str << "EBLOB: failed to start defragmentation, err: " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 }
@@ -236,13 +248,11 @@ int eblob::defrag_status()
 
 void eblob::prepare(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
 {
-	int err;
-
-	err = eblob_write_prepare(eblob_, (struct eblob_key *)&key, size, flags);
+	int err = eblob_write_prepare(eblob_, (struct eblob_key *)&key, size, flags);
 	if (err) {
 		std::ostringstream str;
 		str << "EBLOB: " << eblob_dump_id(key.id) << ": failed to prepare for size: "
-			<< size << ", err: " << err;
+			<< size << ", err: " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 }
@@ -276,7 +286,12 @@ void eblob::iterate(const struct eblob_iterate_callbacks *callbacks, unsigned in
 	ctl.iterator_cb = *callbacks;
 	ctl.priv = priv;
 
-	eblob_iterate(eblob_, &ctl);
+	int err = eblob_iterate(eblob_, &ctl);
+	if (err) {
+		std::ostringstream str;
+		str << "EBLOB: iteration failed: " << strerror(-err);
+		throw std::runtime_error(str.str());
+	}
 }
 
 void eblob::plain_write(const struct eblob_key &key, const void *data, const uint64_t offset,
@@ -285,7 +300,8 @@ void eblob::plain_write(const struct eblob_key &key, const void *data, const uin
 	int err = eblob_plain_write(eblob_, (struct eblob_key *)&key, (void *)data, offset, size, flags);
 	if (err) {
 		std::ostringstream str;
-		str << eblob_dump_id(key.id) << ": eblob plain write failed: offset: " << offset << ", size: " << size << ", flags: " << flags << ": " << strerror(-err);
+		str << "EBLOB: " << eblob_dump_id(key.id) << ": eblob plain write failed: offset: "
+			<< offset << ", size: " << size << ", flags: " << flags << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
 }

--- a/bindings/cpp/eblob.cpp
+++ b/bindings/cpp/eblob.cpp
@@ -63,12 +63,12 @@ eblob::~eblob()
 	eblob_cleanup(eblob_);
 }
 
-int eblob::key(const std::string &key, struct eblob_key &ekey)
+void eblob::key(const std::string &key, struct eblob_key &ekey)
 {
-	return eblob_hash(eblob_, ekey.id, sizeof(ekey.id), key.data(), key.size());
+	eblob_hash(eblob_, ekey.id, sizeof(ekey.id), key.data(), key.size());
 }
 
-int eblob::write(const struct eblob_key &key, const void *data, const uint64_t offset, const uint64_t dsize, uint64_t flags)
+void eblob::write(const struct eblob_key &key, const void *data, const uint64_t offset, const uint64_t dsize, uint64_t flags)
 {
 	int err = eblob_write(eblob_, (struct eblob_key *)&key, (void *)data, offset, dsize, flags);
 	if (err) {
@@ -76,13 +76,11 @@ int eblob::write(const struct eblob_key &key, const void *data, const uint64_t o
 		str << "eblob write failed: dsize: " << dsize << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }
 
-int eblob::write(const struct eblob_key &key, const std::string &data, const uint64_t offset, uint64_t flags)
+void eblob::write(const struct eblob_key &key, const std::string &data, const uint64_t offset, uint64_t flags)
 {
-	return write(key, data.data(), offset, data.size(), flags);
+	write(key, data.data(), offset, data.size(), flags);
 }
 
 int eblob::read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size)
@@ -143,26 +141,26 @@ std::string eblob::read(const struct eblob_key &key, const uint64_t req_offset,
 	return ret;
 }
 
-int eblob::write_hashed(const std::string &key, const std::string &data, const uint64_t offset, uint64_t flags)
+void eblob::write_hashed(const std::string &key, const std::string &data, const uint64_t offset, uint64_t flags)
 {
 	struct eblob_key ekey;
 
 	eblob_hash(eblob_, ekey.id, sizeof(ekey.id), key.data(), key.size());
-	return write(ekey, data, offset, flags);
+	write(ekey, data, offset, flags);
 }
 
-int eblob::read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size)
+void eblob::read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size)
 {
-	return read_hashed(key, fd, offset, size, EBLOB_READ_CSUM);
+	read_hashed(key, fd, offset, size, EBLOB_READ_CSUM);
 }
 
-int eblob::read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size,
+void eblob::read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size,
 		enum eblob_read_flavour csum)
 {
 	struct eblob_key ekey;
 
 	eblob_hash(eblob_, ekey.id, sizeof(ekey.id), key.data(), key.size());
-	return read(ekey, fd, offset, size, csum);
+	read(ekey, fd, offset, size, csum);
 }
 
 std::string eblob::read_hashed(const std::string &key, const uint64_t offset, const uint64_t size)
@@ -179,9 +177,9 @@ std::string eblob::read_hashed(const std::string &key, const uint64_t offset, co
 	return read(ekey, offset, size, csum);
 }
 
-int eblob::remove(const struct eblob_key &key)
+void eblob::remove(const struct eblob_key &key)
 {
-	return eblob_remove(eblob_, (struct eblob_key *)&key);
+	eblob_remove(eblob_, (struct eblob_key *)&key);
 }
 
 unsigned long long eblob::elements(void)
@@ -189,9 +187,9 @@ unsigned long long eblob::elements(void)
 	return eblob_total_elements(eblob_);
 }
 
-int eblob::remove_hashed(const std::string &key)
+void eblob::remove_hashed(const std::string &key)
 {
-	return eblob_remove_hashed(eblob_, key.data(), key.size());
+	eblob_remove_hashed(eblob_, key.data(), key.size());
 }
 
 void eblob::remove_blobs(void)
@@ -199,7 +197,7 @@ void eblob::remove_blobs(void)
 	eblob_remove_blobs(eblob_);
 }
 
-int eblob::truncate(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
+void eblob::truncate(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
 {
 	int err;
 
@@ -210,20 +208,17 @@ int eblob::truncate(const struct eblob_key &key, const uint64_t size, const uint
 			", flags: " << flags << ", err: " << err;
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }
 
-int eblob::truncate_hashed(const std::string &key, const uint64_t size, const uint64_t flags)
+void eblob::truncate_hashed(const std::string &key, const uint64_t size, const uint64_t flags)
 {
 	struct eblob_key ekey;
 
 	eblob_hash(eblob_, ekey.id, sizeof(ekey.id), key.data(), key.size());
-
-	return truncate(ekey, size, flags);
+	truncate(ekey, size, flags);
 }
 
-int eblob::start_defrag()
+void eblob::start_defrag()
 {
 	int err;
 	err = eblob_start_defrag(eblob_);
@@ -232,8 +227,6 @@ int eblob::start_defrag()
 		str << "EBLOB: failed to start defragmentation, err: " << err;
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }
 
 int eblob::defrag_status()
@@ -241,7 +234,7 @@ int eblob::defrag_status()
 	return eblob_defrag_status(eblob_);
 }
 
-int eblob::prepare(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
+void eblob::prepare(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
 {
 	int err;
 
@@ -252,28 +245,26 @@ int eblob::prepare(const struct eblob_key &key, const uint64_t size, const uint6
 			<< size << ", err: " << err;
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }
 
-int eblob::prepare_hashed(const std::string &kdata, const uint64_t size, const uint64_t flags)
+void eblob::prepare_hashed(const std::string &kdata, const uint64_t size, const uint64_t flags)
 {
 	struct eblob_key key;
 
 	eblob_hash(eblob_, key.id, sizeof(key.id), kdata.data(), kdata.size());
-	return prepare(key, size, flags);
+	prepare(key, size, flags);
 }
 
-int eblob::commit(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
+void eblob::commit(const struct eblob_key &key, const uint64_t size, const uint64_t flags)
 {
-	return truncate(key, size, flags);
+	truncate(key, size, flags);
 }
-int eblob::commit_hashed(const std::string &key, const uint64_t size, const uint64_t flags)
+void eblob::commit_hashed(const std::string &key, const uint64_t size, const uint64_t flags)
 {
-	return truncate_hashed(key, size, flags);
+	truncate_hashed(key, size, flags);
 }
 
-int eblob::iterate(const struct eblob_iterate_callbacks *callbacks, unsigned int flags, void *priv)
+void eblob::iterate(const struct eblob_iterate_callbacks *callbacks, unsigned int flags, void *priv)
 {
 	struct eblob_iterate_control ctl;
 
@@ -285,10 +276,10 @@ int eblob::iterate(const struct eblob_iterate_callbacks *callbacks, unsigned int
 	ctl.iterator_cb = *callbacks;
 	ctl.priv = priv;
 
-	return eblob_iterate(eblob_, &ctl);
+	eblob_iterate(eblob_, &ctl);
 }
 
-int eblob::plain_write(const struct eblob_key &key, const void *data, const uint64_t offset,
+void eblob::plain_write(const struct eblob_key &key, const void *data, const uint64_t offset,
 				const uint64_t size, const uint64_t flags)
 {
 	int err = eblob_plain_write(eblob_, (struct eblob_key *)&key, (void *)data, offset, size, flags);
@@ -297,6 +288,4 @@ int eblob::plain_write(const struct eblob_key &key, const void *data, const uint
 		str << eblob_dump_id(key.id) << ": eblob plain write failed: offset: " << offset << ", size: " << size << ", flags: " << flags << ": " << strerror(-err);
 		throw std::runtime_error(str.str());
 	}
-
-	return err;
 }

--- a/include/eblob/eblob.hpp
+++ b/include/eblob/eblob.hpp
@@ -78,11 +78,11 @@ class eblob {
 		eblob(const char *log_file, const int log_level, struct eblob_config *cfg);
 		virtual ~eblob();
 
-		int write(const struct eblob_key &key, const void *data, const uint64_t offset, const uint64_t dsize,
+		void write(const struct eblob_key &key, const void *data, const uint64_t offset, const uint64_t dsize,
 				uint64_t flags = 0);
-		int write(const struct eblob_key &key, const std::string &data, const uint64_t offset = 0,
+		void write(const struct eblob_key &key, const std::string &data, const uint64_t offset = 0,
 				uint64_t flags = 0);
-		int write_hashed(const std::string &key, const std::string &data, const uint64_t offset,
+		void write_hashed(const std::string &key, const std::string &data, const uint64_t offset,
 				uint64_t flags = 0);
 
 		std::string read(const struct eblob_key &key, const uint64_t offset, const uint64_t size);
@@ -94,35 +94,35 @@ class eblob {
 		int read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size,
 				enum eblob_read_flavour csum);
 
-		int read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size);
-		int read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size,
+		void read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size);
+		void read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size,
 				enum eblob_read_flavour csum);
 		std::string read_hashed(const std::string &key, const uint64_t offset, const uint64_t size);
 		std::string read_hashed(const std::string &key, const uint64_t offset, const uint64_t size,
 				enum eblob_read_flavour csum);
 
-		int remove(const struct eblob_key &key);
-		int remove_hashed(const std::string &key);
+		void remove(const struct eblob_key &key);
+		void remove_hashed(const std::string &key);
 
 		unsigned long long elements(void);
 
 		void remove_blobs(void);
 
-		int iterate(const struct eblob_iterate_callbacks *callbacks, unsigned int flags, void *priv);
+		void iterate(const struct eblob_iterate_callbacks *callbacks, unsigned int flags, void *priv);
 
-		int key(const std::string &key, struct eblob_key &ekey);
+		void key(const std::string &key, struct eblob_key &ekey);
 
-		int prepare(const struct eblob_key &key, const uint64_t size, const uint64_t flags = 0);
-		int prepare_hashed(const std::string &kdata, const uint64_t size, const uint64_t flags = 0);
-		int commit(const struct eblob_key &key, const uint64_t size = -1, const uint64_t flags = -1);
-		int commit_hashed(const std::string &key, const uint64_t size = -1, const uint64_t flags = -1);
-		int plain_write(const struct eblob_key &key, const void *data, const uint64_t offset,
+		void prepare(const struct eblob_key &key, const uint64_t size, const uint64_t flags = 0);
+		void prepare_hashed(const std::string &kdata, const uint64_t size, const uint64_t flags = 0);
+		void commit(const struct eblob_key &key, const uint64_t size = -1, const uint64_t flags = -1);
+		void commit_hashed(const std::string &key, const uint64_t size = -1, const uint64_t flags = -1);
+		void plain_write(const struct eblob_key &key, const void *data, const uint64_t offset,
 				const uint64_t size, const uint64_t flags);
 
-		int truncate(const struct eblob_key &key, const uint64_t size, const uint64_t flags = -1);
-		int truncate_hashed(const std::string &key, const uint64_t size, const uint64_t flags = -1);
+		void truncate(const struct eblob_key &key, const uint64_t size, const uint64_t flags = -1);
+		void truncate_hashed(const std::string &key, const uint64_t size, const uint64_t flags = -1);
 
-		int start_defrag();
+		void start_defrag();
 		int defrag_status();
 
 		struct eblob_log *log() {

--- a/include/eblob/eblob.hpp
+++ b/include/eblob/eblob.hpp
@@ -90,8 +90,8 @@ class eblob {
 				enum eblob_read_flavour csum);
 
 		/* read() returns exception on error, zero on success, positive return value if data is compressed */
-		int read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size);
-		int read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size,
+		void read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size);
+		void read(const struct eblob_key &key, int *fd, uint64_t *offset, uint64_t *size,
 				enum eblob_read_flavour csum);
 
 		void read_hashed(const std::string &key, int *fd, uint64_t *offset, uint64_t *size);

--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -85,16 +85,18 @@ class eblob_test {
 			}
 		}
 
-		void remove(int start)
+		void remove(int start, const std::vector<std::string>& prefixes)
 		{
 			for (int i = start; i < m_iterations; ++i) {
-				std::ostringstream key;
+				for(std::vector<std::string>::const_iterator p = prefixes.begin();
+						p != prefixes.end(); ++p) {
+					std::ostringstream key;
+					key << *p << m_key_base << i;
 
-				key << m_key_base << i;
-
-				struct eblob_key ekey;
-				m_blob->key(key.str(), ekey);
-				m_blob->remove(ekey);
+					struct eblob_key ekey;
+					m_blob->key(key.str(), ekey);
+					m_blob->remove(ekey);
+				}
 			}
 			m_iterations = start;
 		}
@@ -137,7 +139,7 @@ int main()
 		t.check(prefixes);
 
 		// Fragment
-		t.remove(iterations / 4);
+		t.remove(iterations / 4, prefixes);
 
 		// Wait
 		std::cout << "Sleeping " << timeout << " seconds waiting for defragmentation" << std::endl;


### PR DESCRIPTION
I've returned using exception instead of error code in eblob c++ binding and made messages of these exceptions in common style. Also I've fixed cpp tests.