### PR TITLE
fixed defrag: data is sorted check on invalid bctl

### DIFF
--- a/library/defrag.c
+++ b/library/defrag.c
@@ -284,7 +284,7 @@ int eblob_defrag(struct eblob_backend *b)
 				 */
 				if (dcfg.bctl_cnt != 1 ||
 				    eblob_want_defrag(*dcfg.bctl) == EBLOB_DEFRAG_NEEDED ||
-				    datasort_base_is_sorted(bctl) != 1) {
+				    datasort_base_is_sorted(*dcfg.bctl) != 1) {
 					EBLOB_WARNX(b->cfg.log, EBLOB_LOG_INFO,
 							"defrag: sorting: %d base(s)", current - previous);
 					if ((err = eblob_generate_sorted_data(&dcfg)) != 0)


### PR DESCRIPTION
Small bugfix: sorting of already sorted blobs. It happens if these blobs were sorted because of EBLOB_MERGE_NEEDED and then initiated backend defrag.