### PR TITLE
Changes to replace reverted commit https://github.com/reverbrain/eblob/commit/066f2c32b0c03db08fd80355f609c2d08151df10

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -494,6 +494,7 @@ int eblob_cache_remove(struct eblob_backend *b, struct eblob_key *key);
 int eblob_cache_remove_nolock(struct eblob_backend *b, struct eblob_key *key);
 int eblob_cache_insert(struct eblob_backend *b, struct eblob_key *key,
 		struct eblob_ram_control *ctl);
+int eblob_cache_empty(struct eblob_backend *b);
 int eblob_disk_index_lookup(struct eblob_backend *b, struct eblob_key *key,
 		struct eblob_ram_control *rctl);
 

--- a/library/hash.c
+++ b/library/hash.c
@@ -209,3 +209,7 @@ int eblob_hash_lookup(struct eblob_hash *h, struct eblob_key *key, void *data)
 	pthread_rwlock_unlock(&h->root_lock);
 	return err;
 }
+
+int eblob_hash_empty(struct eblob_hash *h) {
+	return (h == NULL) || (rb_first(&h->root) == NULL);
+}

--- a/library/hash.h
+++ b/library/hash.h
@@ -38,6 +38,7 @@ int eblob_hash_remove_nolock(struct eblob_hash *h, struct eblob_key *key);
 int eblob_hash_lookup_nolock(struct eblob_hash *h, struct eblob_key *key, void *datap);
 int eblob_hash_lookup(struct eblob_hash *h, struct eblob_key *key, void *datap);
 int eblob_hash_replace_nolock(struct eblob_hash *h, struct eblob_key *key, void *data, int *replaced);
+int eblob_hash_empty(struct eblob_hash *h);
 
 struct eblob_hash_entry {
 	struct eblob_key	key;

--- a/library/l2hash.c
+++ b/library/l2hash.c
@@ -666,3 +666,7 @@ int eblob_l2hash_upsert(struct eblob_l2hash *l2h, const struct eblob_key *key,
 {
 	return _eblob_l2hash_insert(l2h, key, rctl, EBLOB_L2HASH_FLAVOR_UPSERT, replaced);
 }
+
+int eblob_l2hash_empty(struct eblob_l2hash *l2h) {
+	return (l2h == NULL) || (rb_first(&l2h->root) == NULL);
+}

--- a/library/l2hash.h
+++ b/library/l2hash.h
@@ -97,5 +97,6 @@ int eblob_l2hash_remove(struct eblob_l2hash *l2h, const struct eblob_key *key);
 int eblob_l2hash_update(struct eblob_l2hash *l2h, const struct eblob_key *key, const struct eblob_ram_control *rctl);
 int eblob_l2hash_upsert(struct eblob_l2hash *l2h, const struct eblob_key *key,
 		const struct eblob_ram_control *rctl, int *replaced);
+int eblob_l2hash_empty(struct eblob_l2hash *l2h);
 
 #endif /* __EBLOB_L2HASH_H */

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -748,6 +748,20 @@ err_out_exit:
 	return err;
 }
 
+int eblob_cache_empty(struct eblob_backend *b) {
+	int ret = 0;
+
+	pthread_rwlock_rdlock(&b->hash.root_lock);
+	if (b->cfg.blob_flags & EBLOB_L2HASH) {
+		ret = eblob_l2hash_empty(&b->l2hash);
+	} else {
+		ret = eblob_hash_empty(&b->hash);
+	}
+	pthread_rwlock_unlock(&b->hash.root_lock);
+
+	return ret;
+}
+
 static int eblob_blob_iter(struct eblob_disk_control *dc, struct eblob_ram_control *ctl,
 		void *data __attribute_unused__, void *priv,
 		void *thread_priv __attribute_unused__)


### PR DESCRIPTION
indexsort: do not use binlog and do not flush eblob cache if cache is empty