### PR TITLE
move backend lock from eblob_write_prepare_disk() to calling functions

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -1527,7 +1527,7 @@ static int eblob_check_free_space(struct eblob_backend *b, uint64_t size)
 }
 
 /*!
- * Low-level counterpart for \fn eblob_write_prepare_disk()
+ * Low-level counterpart for \fn eblob_write_prepare_disk_nolock()
  * NB! Caller should hold "backend" lock.
  */
 static int eblob_write_prepare_disk_ll(struct eblob_backend *b, struct eblob_key *key,
@@ -1748,11 +1748,10 @@ err_out_exit:
 
 
 /**
- * eblob_write_prepare_disk() - allocates space for new record
- * It locks backend, allocates new bases, commits headers and
- * manages overwrites/appends.
+ * eblob_write_prepare_disk_nolock() - allocates space for new record
+ * It allocates new bases, commits headers and manages overwrites/appends.
  */
-static int eblob_write_prepare_disk(struct eblob_backend *b, struct eblob_key *key,
+static int eblob_write_prepare_disk_nolock(struct eblob_backend *b, struct eblob_key *key,
 		struct eblob_write_control *wc, uint64_t prepare_disk_size,
 		enum eblob_copy_flavour copy, uint64_t copy_offset, struct eblob_ram_control *old,
 		size_t defrag_generation)
@@ -1764,11 +1763,9 @@ static int eblob_write_prepare_disk(struct eblob_backend *b, struct eblob_key *k
 	struct eblob_ram_control upd_old;
 
 	eblob_log(b->cfg.log, EBLOB_LOG_NOTICE,
-			"blob: %s: eblob_write_prepare_disk: start: "
+			"blob: %s: eblob_write_prepare_disk_nolock: start: "
 			"size: %" PRIu64 ", offset: %" PRIu64 ", prepare: %" PRIu64 "\n",
 			eblob_dump_id(key->id), wc->size, wc->offset, prepare_disk_size);
-
-	pthread_mutex_lock(&b->lock);
 
 	if (defrag_generation != b->defrag_generation) {
 		int disk;
@@ -1794,8 +1791,7 @@ static int eblob_write_prepare_disk(struct eblob_backend *b, struct eblob_key *k
 			copy_offset, old);
 
 err_out_exit:
-	pthread_mutex_unlock(&b->lock);
-	eblob_dump_wc(b, key, wc, "eblob_write_prepare_disk", err);
+	eblob_dump_wc(b, key, wc, "eblob_write_prepare_disk_nolock", err);
 	return err;
 }
 
@@ -1821,6 +1817,8 @@ int eblob_write_prepare(struct eblob_backend *b, struct eblob_key *key,
 		goto err_out_exit;
 	}
 
+	pthread_mutex_lock(&b->lock);
+
 	/*
 	 * For eblob_write_prepare() this can fail with -E2BIG if we try to overwrite
 	 * record without footer by record with footer.
@@ -1828,24 +1826,26 @@ int eblob_write_prepare(struct eblob_backend *b, struct eblob_key *key,
 	defrag_generation = b->defrag_generation;
 	err = eblob_fill_write_control_from_ram(b, key, &wc, 1, &old);
 	if (err && err != -ENOENT && err != -E2BIG)
-		goto err_out_exit;
+		goto err_out_unlock;
 
 	if (err == 0 && (wc.total_size >= eblob_calculate_size(b, 0, size))) {
 		eblob_stat_inc(b->stat, EBLOB_GST_PREPARE_REUSED);
-		goto err_out_exit;
+		goto err_out_unlock;
 	} else {
 		wc.flags = flags;
 		if (b->cfg.blob_flags & EBLOB_NO_FOOTER)
 			wc.flags |= BLOB_DISK_CTL_NOCSUM;
 		wc.flags |= BLOB_DISK_CTL_UNCOMMITTED;
-		err = eblob_write_prepare_disk(b, key, &wc, size, EBLOB_COPY_RECORD, 0, err == -ENOENT ? NULL : &old, defrag_generation);
+		err = eblob_write_prepare_disk_nolock(b, key, &wc, size, EBLOB_COPY_RECORD, 0, err == -ENOENT ? NULL : &old, defrag_generation);
 		if (err)
-			goto err_out_exit;
+			goto err_out_unlock;
 		err = eblob_commit_ram(b, key, &wc);
 		if (err)
-			goto err_out_exit;
+			goto err_out_unlock;
 	}
 
+err_out_unlock:
+	pthread_mutex_unlock(&b->lock);
 err_out_exit:
 	eblob_dump_wc(b, key, &wc, "eblob_write_prepare: finished", err);
 	return err;
@@ -2345,22 +2345,26 @@ int eblob_writev_return(struct eblob_backend *b, struct eblob_key *key,
 			wc->flags |= BLOB_DISK_CTL_NOCSUM;
 	}
 
-	err = eblob_write_prepare_disk(b, key, wc, 0, copy, copy_offset, err == -ENOENT ? NULL : &old, defrag_generation);
+	pthread_mutex_lock(&b->lock);
+
+	err = eblob_write_prepare_disk_nolock(b, key, wc, 0, copy, copy_offset, err == -ENOENT ? NULL : &old, defrag_generation);
 	if (err)
-		goto err_out_exit;
+		goto err_out_unlock;
 
 	err = eblob_writev_raw(key, wc, iov, iovcnt);
 	if (err) {
 		eblob_dump_wc(b, key, wc, "eblob_writev: eblob_writev_raw: FAILED", err);
-		goto err_out_exit;
+		goto err_out_unlock;
 	}
 
 	err = eblob_write_commit_nolock(b, key, wc);
 	if (err) {
 		eblob_dump_wc(b, key, wc, "eblob_writev: eblob_write_commit_nolock: FAILED", err);
-		goto err_out_exit;
+		goto err_out_unlock;
 	}
 
+err_out_unlock:
+	pthread_mutex_unlock(&b->lock);
 err_out_exit:
 	eblob_dump_wc(b, key, wc, "eblob_writev: finished", err);
 	if (err) {

--- a/library/blob.c
+++ b/library/blob.c
@@ -1817,6 +1817,11 @@ int eblob_write_prepare(struct eblob_backend *b, struct eblob_key *key,
 		goto err_out_exit;
 	}
 
+	/*
+	 * eblob_write_prepare_disk_nolock(), eblob_commit_ram()
+	 * must be executed as a single transaction, because simultaneously running defragmentation
+	 * may change bctl, which is used in wc
+	 */
 	pthread_mutex_lock(&b->lock);
 
 	/*
@@ -2345,6 +2350,11 @@ int eblob_writev_return(struct eblob_backend *b, struct eblob_key *key,
 			wc->flags |= BLOB_DISK_CTL_NOCSUM;
 	}
 
+	/*
+	 * eblob_write_prepare_disk_nolock(), eblob_writev_raw(), eblob_write_commit_nolock()
+	 * must be executed as a single transaction, because simultaneously running defragmentation
+	 * may change bctl, which is used in wc
+	 */
 	pthread_mutex_lock(&b->lock);
 
 	err = eblob_write_prepare_disk_nolock(b, key, wc, 0, copy, copy_offset, err == -ENOENT ? NULL : &old, defrag_generation);

--- a/library/index.c
+++ b/library/index.c
@@ -790,13 +790,11 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	bctl->sort.fd = fd;
 	bctl->sort.offset = 0;
 	bctl->sort.size = index_size;
-	b->defrag_generation += 1;
 
 	err = eblob_index_blocks_fill(bctl);
 	if (err) {
 		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: eblob_index_blocks_fill: index: %d: FAILED",
 				bctl->index);
-		pthread_mutex_unlock(&bctl->lock);
 		goto err_unlock_hash;
 	}
 
@@ -809,6 +807,8 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 				bctl->index);
 		goto err_unlock_hash;
 	}
+
+	b->defrag_generation += 1;
 
 	/* Unlock */
 	pthread_rwlock_unlock(&b->hash.root_lock);
@@ -836,6 +836,7 @@ err_out_free_index:
 	free(sorted_index);
 err_out_close:
 	close(fd);
+	bctl->sort.fd = -1;
 err_out_free_dst_file:
 	free(dst_file);
 err_out_free_file:


### PR DESCRIPTION
Issue: https://github.com/reverbrain/eblob/issues/118

The problem is reproduced when some delay happens between calling eblob_write_prepare_disk() and eblob_commit_ram(), while defragmentation process is running and L2 cache enabled. These conditions causes inserting to L2 hash (cache) ram control with pointer to bctl which was already defragmented. After that, writing of a new key, which has same L2 hash leads to collision resolving by reading full 64 byte key from bctl (which points to the sorted blob with '-1' blob and index descriptors).