### PR TITLE
quigon build fix: don't use /dev/stdout from forked processes

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,26 +1,39 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
-set -x
+run_tests()
+{
+    set -e
+    set -x
 
-# Run python bindings test
-$(find . -name test.py)
+    # Run python bindings test
+    $(find . -name test.py)
 
-# Run cpp bindings test
-$(find . -name eblob_cpp_test)
+    # Run cpp bindings test
+    $(find . -name eblob_cpp_test)
 
-# Run unit tests
-$(find . -name eblob_crypto_test)
+    # Run unit tests
+    $(find . -name eblob_crypto_test)
 
-# Big and small stress tests
-$(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F87
-$(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F14
-$(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F2135
-$(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F2062
+    # Big and small stress tests
+    $(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F87
+    $(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F14
+    $(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F2135
+    $(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F2062
 
-# Use specific datasort_dir for sorting chunks
-$(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F2263 -P 1
+    # Use specific datasort_dir for sorting chunks
+    $(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F2263 -P 1
 
-# Overwrite-heavy test with many bases and threads
-$(find . -name eblob_stress) -f1000 -D0 -I100000 -i64 -r 40 -S10 -F64 -T32 -l4 -o 0
-$(find . -name eblob_stress) -f1000 -D0 -I100000 -i64 -r 40 -S10 -F2112 -T32 -l4 -o 0
+    # Overwrite-heavy test with many bases and threads
+    $(find . -name eblob_stress) -f1000 -D0 -I100000 -i64 -r 40 -S10 -F64 -T32 -l4 -o 0
+    $(find . -name eblob_stress) -f1000 -D0 -I100000 -i64 -r 40 -S10 -F2112 -T32 -l4 -o 0
+}
+
+echo -e "\n####################################################################"
+echo -e "                            RUNNING TESTS\n"
+
+run_tests >tests_result.log 2>&1 &
+wait
+echo "$(<tests_result.log)"
+
+echo -e "\n                          TESTS FINISHED"
+echo -e "####################################################################\n"


### PR DESCRIPTION
/dev/stdout is not available after fork+exec inside pbuilder environment
This PR contains workaround for such strange behaviour of pbuilder: tests are started in background with stderr & stdout redirected to the file. After tests complete, this file is printed using internal bash "echo" command.