### PR TITLE
blob: allow to overwrite old or broken keys

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -2149,30 +2149,6 @@ static int eblob_plain_writev_prepare(struct eblob_backend *b, struct eblob_key 
 	if (err)
 		goto err_out_unlock;
 
-	/*
-	 * We can't use plain write if EXTHDR flag is differ on old and new record.
-	 * TODO: We can preform read-modify-write cycle here but it's too hacky.
-	 *
-	 * We allow whole object overwrite, return error only if we are trying to update object
-	 * with non contiguous regions.
-	 */
-	if ((flags & BLOB_DISK_CTL_EXTHDR)
-			&& !(wc->flags & BLOB_DISK_CTL_EXTHDR)) {
-		uint64_t start = 0;
-		int idx;
-
-		for (idx = 0; idx < iovcnt; ++idx) {
-			const struct eblob_iovec *tmp = &iov[idx];
-
-			if (tmp->offset != start) {
-				err = -ENOTSUP;
-				goto err_out_cleanup_wc;
-			}
-
-			start += tmp->size;
-		}
-	}
-
 	wc->flags = eblob_validate_ctl_flags(b, flags);
 
 	/*


### PR DESCRIPTION
Allow to overwrite old or broken keys (without BLOB_DISK_CTL_EXTHDR flag) with contiguous blocks