### PR TITLE
Remove .index files after index sort

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -90,8 +90,9 @@ static const size_t EBLOB_HASH_ENTRY_SIZE = sizeof(struct eblob_ram_control)
 /* Approx. size of l2hash entry (considering there wasn't a collision) */
 static const size_t EBLOB_L2HASH_ENTRY_SIZE = sizeof(struct eblob_l2hash_entry);
 
-struct eblob_map_fd {
+struct eblob_file_ctl {
 	int			fd;
+	int			sorted;
 	uint64_t		offset, size;
 };
 
@@ -134,13 +135,12 @@ struct eblob_base_ctl {
 
 	pthread_mutex_t		lock;
 	pthread_cond_t		critness_wait;
-	int			data_fd, index_fd;
+	int			data_fd;
 	off_t			data_offset;
 
 	unsigned long long	data_size;
-	unsigned long long	index_size;
 
-	struct eblob_map_fd	sort;
+	struct eblob_file_ctl	index_ctl;
 
 	/*
 	 * Bloom
@@ -552,7 +552,6 @@ int eblob_preallocate(int fd, off_t offset, off_t size);
 int eblob_pagecache_hint(int fd, uint64_t flag);
 
 int eblob_mark_index_removed(int fd, uint64_t offset);
-int eblob_get_index_fd(struct eblob_base_ctl *bctl);
 void eblob_base_wait(struct eblob_base_ctl *bctl);
 void eblob_base_wait_locked(struct eblob_base_ctl *bctl);
 

--- a/library/blob.h
+++ b/library/blob.h
@@ -135,11 +135,14 @@ struct eblob_base_ctl {
 
 	pthread_mutex_t		lock;
 	pthread_cond_t		critness_wait;
-	int			data_fd;
-	off_t			data_offset;
 
-	unsigned long long	data_size;
-
+	/*
+	 * Domain of data_ctl.sorted: is data in blob sorted?
+	 * 1 if sorted
+	 * 0 if unknown
+	 * -1 if not sorted
+	 */
+	struct eblob_file_ctl	data_ctl;
 	struct eblob_file_ctl	index_ctl;
 
 	/*
@@ -160,13 +163,6 @@ struct eblob_base_ctl {
 	/* Binary log rudiment: if enabled stores key removals in list */
 	struct eblob_binlog_cfg	binlog;
 
-	/*
-	 * Is data in blob sorted?
-	 * 1 if sorted
-	 * 0 if unknown
-	 * -1 if not sorted
-	 */
-	int			sorted;
 	/* Per bctl aka "local" stats */
 	struct eblob_stat	*stat;
 	char			name[];

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -997,7 +997,7 @@ err_out_exit:
 static int datasort_swap_memory(struct datasort_cfg *dcfg)
 {
 	struct eblob_base_ctl *sorted_bctl, *unsorted_bctl;
-	struct eblob_map_fd index;
+	struct eblob_file_ctl index;
 	char tmp_index_path[PATH_MAX], data_path[PATH_MAX];
 	uint64_t i, offset;
 	int err, n;
@@ -1035,6 +1035,7 @@ static int datasort_swap_memory(struct datasort_cfg *dcfg)
 	 * FIXME: Copy permissions from original fd
 	 */
 	memset(&index, 0, sizeof(index));
+	index.sorted = 1;
 	index.size = dcfg->result->count * sizeof(struct eblob_disk_control);
 	index.fd = open(tmp_index_path, O_RDWR | O_CLOEXEC | O_TRUNC | O_CREAT, 0644);
 	if (index.fd == -1) {
@@ -1074,8 +1075,7 @@ static int datasort_swap_memory(struct datasort_cfg *dcfg)
 	 * Setup sorted base
 	 */
 	sorted_bctl->data_fd = dcfg->result->fd;
-	sorted_bctl->index_fd = index.fd;
-	sorted_bctl->sort = index;
+	sorted_bctl->index_ctl = index;
 
 	/* Setup new base */
 	if ((err = eblob_base_setup_data(sorted_bctl, 1)) != 0) {
@@ -1125,7 +1125,7 @@ static int datasort_swap_memory(struct datasort_cfg *dcfg)
 
 	/* Account for new size */
 	eblob_stat_set(sorted_bctl->stat, EBLOB_LST_BASE_SIZE,
-			sorted_bctl->index_size + sorted_bctl->data_size);
+			sorted_bctl->index_ctl.size + sorted_bctl->data_size);
 	eblob_stat_set(sorted_bctl->stat, EBLOB_LST_RECORDS_TOTAL, dcfg->result->count);
 
 	/*
@@ -1161,7 +1161,7 @@ err:
 static int datasort_swap_disk(struct datasort_cfg *dcfg)
 {
 	struct eblob_base_ctl *sorted_bctl, *unsorted_bctl;
-	char tmp_index_path[PATH_MAX], index_path[PATH_MAX];
+	char tmp_index_path[PATH_MAX];
 	char sorted_index_path[PATH_MAX], data_path[PATH_MAX];
 	char mark_path[PATH_MAX];
 	int err, n;
@@ -1186,8 +1186,7 @@ static int datasort_swap_disk(struct datasort_cfg *dcfg)
 			dcfg->result->path, data_path);
 
 	snprintf(mark_path, PATH_MAX, "%s" EBLOB_DATASORT_SORTED_MARK_SUFFIX, data_path);
-	snprintf(index_path, PATH_MAX, "%s.index", data_path);
-	snprintf(sorted_index_path, PATH_MAX, "%s.sorted", index_path);
+	snprintf(sorted_index_path, PATH_MAX, "%s.index.sorted", data_path);
 	snprintf(tmp_index_path, PATH_MAX, "%s.tmp", sorted_index_path);
 
 	/*
@@ -1220,12 +1219,7 @@ static int datasort_swap_disk(struct datasort_cfg *dcfg)
 				dcfg->result->path, data_path);
 	if (rename(tmp_index_path, sorted_index_path) == -1)
 		EBLOB_WARNC(dcfg->log, EBLOB_LOG_ERROR, errno, "defrag: rename: %s -> %s",
-				tmp_index_path, index_path);
-
-	/* Hardlink sorted index to unsorted one */
-	if (link(sorted_index_path, index_path) == -1)
-		EBLOB_WARNC(dcfg->log, EBLOB_LOG_ERROR, errno, "defrag: link: %s -> %s",
-				sorted_index_path, index_path);
+				tmp_index_path, sorted_index_path);
 
 	/* Leave mark that data file is sorted */
 	if ((err = open(mark_path, O_TRUNC | O_CREAT | O_CLOEXEC, 0644)) != -1) {
@@ -1240,8 +1234,8 @@ static int datasort_swap_disk(struct datasort_cfg *dcfg)
 			"data_fd: %d -> %d, index_fd: %d -> %d",
 			dcfg->result->path, data_path,
 			sorted_bctl->data_fd, unsorted_bctl->data_fd,
-			eblob_get_index_fd(sorted_bctl),
-			eblob_get_index_fd(unsorted_bctl));
+			sorted_bctl->index_ctl.fd,
+			unsorted_bctl->index_ctl.fd);
 	return 0;
 
 err:
@@ -1268,10 +1262,10 @@ static void datasort_cleanup(struct datasort_cfg *dcfg)
 		if (err)
 			EBLOB_WARNC(dcfg->log, EBLOB_LOG_ERROR, -err,
 					"defrag: eblob_pagecache_hint: data: %d", bctl->data_fd);
-		err = eblob_pagecache_hint(bctl->index_fd, EBLOB_FLAGS_HINT_DONTNEED);
+		err = eblob_pagecache_hint(bctl->index_ctl.fd, EBLOB_FLAGS_HINT_DONTNEED);
 		if (err)
 			EBLOB_WARNC(dcfg->log, EBLOB_LOG_ERROR, -err,
-					"defrag: eblob_pagecache_hint: index: %d", bctl->index_fd);
+					"defrag: eblob_pagecache_hint: index: %d", bctl->index_ctl.fd);
 
 		/*
 		 * Cleanup unsorted base

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -72,7 +72,7 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 
 	/* Sanity: Do not remove seem-to-be empty blob if offsets are non-zero */
 	if (((removed == 0) && (total == 0)) &&
-	    ((bctl->data_offset != 0) || (bctl->index_ctl.size != 0)))
+	    ((bctl->data_ctl.offset != 0) || (bctl->index_ctl.size != 0)))
 		return -EINVAL;
 
 	if (total < removed)
@@ -102,7 +102,7 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 			eblob_log(b->cfg.log, EBLOB_LOG_ERROR,
 					"%s: FAILED: trying to remove non empty blob: "
 					"removed: %" PRIu64 ", total: %" PRIu64
-					"index_size: %llu, removed_index_size: %" PRIu64 "\n",
+					"index_size: %" PRIu64 ", removed_index_size: %" PRIu64 "\n",
 					__func__, removed, total,
 					bctl->index_ctl.size, removed_index_size);
 			err = EBLOB_DEFRAG_NEEDED;

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -72,7 +72,7 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 
 	/* Sanity: Do not remove seem-to-be empty blob if offsets are non-zero */
 	if (((removed == 0) && (total == 0)) &&
-	    ((bctl->data_offset != 0) || (bctl->index_size != 0)))
+	    ((bctl->data_offset != 0) || (bctl->index_ctl.size != 0)))
 		return -EINVAL;
 
 	if (total < removed)
@@ -98,13 +98,13 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 		 * size of removed entries
 		 */
 		uint64_t removed_index_size = removed * sizeof(struct eblob_disk_control);
-		if (bctl->index_size != removed_index_size) {
+		if (bctl->index_ctl.size != removed_index_size) {
 			eblob_log(b->cfg.log, EBLOB_LOG_ERROR,
 					"%s: FAILED: trying to remove non empty blob: "
 					"removed: %" PRIu64 ", total: %" PRIu64
 					"index_size: %llu, removed_index_size: %" PRIu64 "\n",
 					__func__, removed, total,
-					bctl->index_size, removed_index_size);
+					bctl->index_ctl.size, removed_index_size);
 			err = EBLOB_DEFRAG_NEEDED;
 		} else {
 			err = EBLOB_REMOVE_NEEDED;
@@ -201,8 +201,8 @@ int eblob_defrag(struct eblob_backend *b)
 		    (b->want_defrag == EBLOB_DEFRAG_STATE_DATA_COMPACT || datasort_base_is_sorted(bctl) == 1))
 			continue;
 
-		/* skips bases with sorted index if defrag thread was started only for index sort*/
-		if (b->want_defrag == EBLOB_DEFRAG_STATE_INDEX_SORT && bctl->sort.fd >= 0)
+		/* skips bases with sorted index if defrag thread was started only for index sort */
+		if (b->want_defrag == EBLOB_DEFRAG_STATE_INDEX_SORT && bctl->index_ctl.sorted)
 			continue;
 
 		/*
@@ -270,7 +270,7 @@ int eblob_defrag(struct eblob_backend *b)
 			case EBLOB_DEFRAG_STATE_INDEX_SORT: {
 				struct eblob_base_ctl * const bctl = bctls[previous];
 				/* If defrag started only for index sort - check that blob's index is unsorted. */
-				if (bctl->sort.fd < 0) {
+				if (!bctl->index_ctl.sorted) {
 					err = eblob_generate_sorted_index(b, bctl);
 					if (err) {
 						EBLOB_WARNC(b->cfg.log, -err, EBLOB_LOG_ERROR, "defrag: indexsort: FAILED");

--- a/library/index.c
+++ b/library/index.c
@@ -576,12 +576,12 @@ static int indexsort_binlog_apply(struct eblob_base_ctl *bctl, void *sorted_inde
 			dc->flags |= BLOB_DISK_CTL_REMOVE;
 
 			EBLOB_WARNX(bctl->back->cfg.log, EBLOB_LOG_DEBUG, "%s: indexsort: removing: fd: %d, offset: %" PRIu64,
-			            eblob_dump_id(it->key.id), bctl->data_fd, dc->position);
-			err = eblob_mark_index_removed(bctl->data_fd, dc->position);
+			            eblob_dump_id(it->key.id), bctl->data_ctl.fd, dc->position);
+			err = eblob_mark_index_removed(bctl->data_ctl.fd, dc->position);
 			if (err != 0) {
 				EBLOB_WARNX(bctl->back->cfg.log, EBLOB_LOG_ERROR,
 						"%s: indexsort: eblob_mark_index_removed: FAILED: data, fd: %d, err: %d",
-						eblob_dump_id(it->key.id), bctl->data_fd, err);
+						eblob_dump_id(it->key.id), bctl->data_ctl.fd, err);
 				goto err_out_exit;
 			}
 			dc += 1;
@@ -823,8 +823,8 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	unlink(file);
 
 	eblob_log(b->cfg.log, EBLOB_LOG_INFO, "defrag: indexsort: generated sorted: index: %d, "
-			"index-size: %llu, data-size: %llu, file: %s\n",
-			bctl->index, (unsigned long long)index_size, (unsigned long long)bctl->data_offset, dst_file);
+			"index-size: %llu, data-size: %" PRIu64 ", file: %s\n",
+			bctl->index, (unsigned long long)index_size, bctl->data_ctl.offset, dst_file);
 
 	free(sorted_index);
 	free(file);

--- a/library/index.c
+++ b/library/index.c
@@ -188,7 +188,7 @@ static uint64_t eblob_bloom_size(const struct eblob_base_ctl *bctl)
 	uint64_t bloom_size = 0;
 
 	/* Number of record in base */
-	bloom_size += bctl->sort.size / sizeof(struct eblob_disk_control);
+	bloom_size += bctl->index_ctl.size / sizeof(struct eblob_disk_control);
 	/* Number of index blocks in base */
 	bloom_size /= bctl->back->cfg.index_block_size;
 	/* Add one for tiny bases */
@@ -215,7 +215,7 @@ static uint8_t eblob_bloom_func_num(const struct eblob_base_ctl *bctl)
 	uint8_t func_num = 0;
 
 	bits_per_key = 8 * bctl->bloom_size /
-		(bctl->sort.size / sizeof(struct eblob_disk_control));
+		(bctl->index_ctl.size / sizeof(struct eblob_disk_control));
 	func_num = bits_per_key * 0.69;
 	if (func_num == 0)
 		return 1;
@@ -250,7 +250,7 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 	eblob_stat_set(bctl->stat, EBLOB_LST_BLOOM_SIZE, bctl->bloom_size);
 
 	/* Pre-allcate all index blocks */
-	block_count = howmany(bctl->sort.size / sizeof(struct eblob_disk_control),
+	block_count = howmany(bctl->index_ctl.size / sizeof(struct eblob_disk_control),
 			bctl->back->cfg.index_block_size);
 	bctl->index_blocks = calloc(block_count, sizeof(struct eblob_index_block));
 	if (bctl->index_blocks == NULL) {
@@ -260,11 +260,11 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 	eblob_stat_set(bctl->stat, EBLOB_LST_INDEX_BLOCKS_SIZE,
 			block_count * sizeof(struct eblob_index_block));
 
-	while (offset < bctl->sort.size) {
+	while (offset < bctl->index_ctl.size) {
 		block = &bctl->index_blocks[block_id++];
 		block->start_offset = offset;
-		for (i = 0; i < bctl->back->cfg.index_block_size && offset < bctl->sort.size; ++i) {
-			err = pread(bctl->sort.fd, &dc, sizeof(struct eblob_disk_control), offset);
+		for (i = 0; i < bctl->back->cfg.index_block_size && offset < bctl->index_ctl.size; ++i) {
+			err = pread(bctl->index_ctl.fd, &dc, sizeof(struct eblob_disk_control), offset);
 			if (err != sizeof(struct eblob_disk_control)) {
 				if (err < 0)
 					err = -errno;
@@ -344,10 +344,10 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 	pthread_rwlock_rdlock(&bctl->index_blocks_lock);
 	block = eblob_index_blocks_search_nolock(bctl, dc, st);
 	if (block) {
-		assert((bctl->sort.size - block->start_offset) / hdr_size > 0);
-		assert((bctl->sort.size - block->start_offset) % hdr_size == 0);
+		assert((bctl->index_ctl.size - block->start_offset) / hdr_size > 0);
+		assert((bctl->index_ctl.size - block->start_offset) % hdr_size == 0);
 
-		num = (bctl->sort.size - block->start_offset) / hdr_size;
+		num = (bctl->index_ctl.size - block->start_offset) / hdr_size;
 
 		if (num > b->cfg.index_block_size)
 			num = b->cfg.index_block_size;
@@ -374,12 +374,12 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 		goto err_out_exit;
 	}
 
-	read_err = __eblob_read_ll(bctl->sort.fd, hdr_block, hdr_block_size, hdr_block_offset);
+	read_err = __eblob_read_ll(bctl->index_ctl.fd, hdr_block, hdr_block_size, hdr_block_offset);
 	if (read_err < 0) {
 		err = read_err;
 		eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "%s: index: %d, position: %" PRIu64 ", block_size: %zu, blob_size: %zd, num: %zu, FAILED: %s: %d.\n",
 			  eblob_dump_id(dc->key.id),
-			  bctl->sort.fd, hdr_block_offset, hdr_block_size, bctl->sort.size, num, strerror(-err), err);
+			  bctl->index_ctl.fd, hdr_block_offset, hdr_block_size, bctl->index_ctl.size, num, strerror(-err), err);
 		goto err_out_free_index;
 	}
 
@@ -390,7 +390,7 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 
 	eblob_log(b->cfg.log, EBLOB_LOG_SPAM, "%s: position: %" PRIu64 ", block_size: %zu, blob_size: %zd, num: %zu\n",
 			eblob_dump_id(dc->key.id),
-			hdr_block_offset, hdr_block_size, bctl->sort.size, num);
+			hdr_block_offset, hdr_block_size, bctl->index_ctl.size, num);
 
 	eblob_log(b->cfg.log, EBLOB_LOG_SPAM, "%s: bsearch range: start: %s, end: %s, num: %zd\n",
 			eblob_dump_id(dc->key.id),
@@ -420,10 +420,10 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 		if (++sorted > end) {
 			/* read next block of headers */
 			hdr_block_offset += hdr_block_size;
-			if (hdr_block_offset >= bctl->sort.size)
+			if (hdr_block_offset >= bctl->index_ctl.size)
 				break;
 
-			num = (bctl->sort.size - hdr_block_offset) / hdr_size;
+			num = (bctl->index_ctl.size - hdr_block_offset) / hdr_size;
 
 			if (num > b->cfg.index_block_size)
 				num = b->cfg.index_block_size;
@@ -432,12 +432,12 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 			sorted = hdr_block;
 			end = sorted + (num - 1);
 
-			read_err = __eblob_read_ll(bctl->sort.fd, hdr_block, hdr_block_size, hdr_block_offset);
+			read_err = __eblob_read_ll(bctl->index_ctl.fd, hdr_block, hdr_block_size, hdr_block_offset);
 			if (read_err < 0) {
 				err = read_err;
 				eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "%s: index: %d, position: %" PRIu64 ", block_size: %zu, blob_size: %zd, num: %zu, FAILED: %s: %d.\n",
 					  eblob_dump_id(dc->key.id),
-					  bctl->sort.fd, hdr_block_offset, hdr_block_size, bctl->sort.size, num, strerror(-err), err);
+					  bctl->index_ctl.fd, hdr_block_offset, hdr_block_size, bctl->index_ctl.size, num, strerror(-err), err);
 				break;
 			}
 		}
@@ -479,12 +479,12 @@ static int eblob_find_on_disk(struct eblob_backend *b,
 			hdr_block_offset -= hdr_block_size;
 		}
 
-		read_err = __eblob_read_ll(bctl->sort.fd, hdr_block, hdr_block_size, hdr_block_offset);
+		read_err = __eblob_read_ll(bctl->index_ctl.fd, hdr_block, hdr_block_size, hdr_block_offset);
 		if (read_err < 0) {
 			err = read_err;
 			eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "%s: index: %d, position: %" PRIu64 ", block_size: %zu, blob_size: %zd, num: %zu, FAILED: %s: %d.\n",
 				  eblob_dump_id(dc->key.id),
-				  bctl->sort.fd, hdr_block_offset, hdr_block_size, bctl->sort.size, num, strerror(-err), err);
+				  bctl->index_ctl.fd, hdr_block_offset, hdr_block_size, bctl->index_ctl.size, num, strerror(-err), err);
 			break;
 		}
 
@@ -684,7 +684,7 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 		goto err_out_free_dst_file;
 	}
 
-	index_size = eblob_get_actual_size(bctl->index_fd);
+	index_size = eblob_get_actual_size(bctl->index_ctl.fd);
 	if (index_size <= 0) {
 		err = index_size ? -errno : 0;
 		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: actual-size: index: %d: %s",
@@ -716,7 +716,7 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 		goto err_out_free_index;
 	}
 
-	err = __eblob_read_ll(bctl->index_fd, sorted_index, index_size, 0);
+	err = __eblob_read_ll(bctl->index_ctl.fd, sorted_index, index_size, 0);
 	if (err) {
 		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: read: index: %d, size: %llu: %s",
 					bctl->index, (unsigned long long)index_size, file);
@@ -787,9 +787,12 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 		goto err_unlock_hash;
 	}
 
-	bctl->sort.fd = fd;
-	bctl->sort.offset = 0;
-	bctl->sort.size = index_size;
+	close(bctl->index_ctl.fd);
+
+	bctl->index_ctl.fd = fd;
+	bctl->index_ctl.offset = 0;
+	bctl->index_ctl.size = index_size;
+	bctl->index_ctl.sorted = 1;
 
 	err = eblob_index_blocks_fill(bctl);
 	if (err) {
@@ -815,6 +818,10 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	pthread_mutex_unlock(&bctl->lock);
 	pthread_mutex_unlock(&b->lock);
 
+	/* Remove unsorted index. It will not be used anymore. */
+	snprintf(file, len, "%s-0.%d.index", b->cfg.file, bctl->index);
+	unlink(file);
+
 	eblob_log(b->cfg.log, EBLOB_LOG_INFO, "defrag: indexsort: generated sorted: index: %d, "
 			"index-size: %llu, data-size: %llu, file: %s\n",
 			bctl->index, (unsigned long long)index_size, (unsigned long long)bctl->data_offset, dst_file);
@@ -836,7 +843,6 @@ err_out_free_index:
 	free(sorted_index);
 err_out_close:
 	close(fd);
-	bctl->sort.fd = -1;
 err_out_free_dst_file:
 	free(dst_file);
 err_out_free_file:
@@ -888,7 +894,7 @@ again:
 		 * was mentioned - it's really rare case.
 		 * TODO: Probably we should check for this inside eblob_bctl_hold()
 		 */
-		if (bctl->index_fd < 0) {
+		if (bctl->index_ctl.fd < 0) {
 			eblob_bctl_release(bctl);
 			if (tries++ > max_tries)
 				return -EDEADLK;
@@ -896,7 +902,7 @@ again:
 		}
 
 		/* If bctl does not have sorted index - skip it, all its keys are already in ram */
-		if (bctl->sort.fd < 0) {
+		if (!bctl->index_ctl.sorted) {
 			st.no_sort++;
 			eblob_log(b->cfg.log, EBLOB_LOG_DEBUG,
 					"blob: %s: index: disk: index: %d: no sorted index\n",

--- a/library/index.c
+++ b/library/index.c
@@ -726,20 +726,6 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	qsort(sorted_index, index_size / sizeof(struct eblob_disk_control), sizeof(struct eblob_disk_control),
 			eblob_disk_control_sort_with_flags);
 
-	err = __eblob_write_ll(fd, sorted_index, index_size, 0);
-	if (err) {
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: write: index: %d, size: %llu: %s",
-			bctl->index, (unsigned long long)index_size, file);
-		goto err_out_free_index;
-	}
-
-	if ((err = fsync(fd)) == -1) {
-		err = -errno;
-		EBLOB_WARNC(b->cfg.log, EBLOB_LOG_ERROR, -err, "defrag: indexsort: fsync: index: %d, size: %llu: %s",
-			bctl->index, (unsigned long long)index_size, file);
-		goto err_out_free_index;
-	}
-
 	/* Lock backend */
 	pthread_mutex_lock(&b->lock);
 	/* Wait for pending writes to finish and lock bctl(s) */

--- a/library/l2hash.c
+++ b/library/l2hash.c
@@ -125,7 +125,7 @@ static int __eblob_l2hash_index_hdr(const struct eblob_ram_control *rctl, struct
 	assert(rctl->bctl != NULL);
 	assert(dc != NULL);
 
-	err = pread(eblob_get_index_fd(rctl->bctl), dc,
+	err = pread(rctl->bctl->index_ctl.fd, dc,
 			sizeof(struct eblob_disk_control), rctl->index_offset);
 	if (err != sizeof(struct eblob_disk_control))
 		return (err == -1) ? -errno : -EINTR; /* TODO: handle signal case gracefully */

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -76,6 +76,11 @@ int eblob_base_setup_data(struct eblob_base_ctl *ctl, int force)
 	}
 	ctl->index_ctl.size = st.st_size;
 
+	if (ctl->index_ctl.size % sizeof(struct eblob_disk_control)) {
+		err = -EBADF;
+		goto err_out_exit;
+	}
+
 	err = fstat(ctl->data_ctl.fd, &st);
 	if (err) {
 		err = -errno;
@@ -152,11 +157,6 @@ static int eblob_base_open_sorted(struct eblob_base_ctl *bctl, const char *dir_b
 	err = eblob_base_setup_data(bctl, 0);
 	if (err)
 		goto err_out_close;
-
-	if (bctl->index_ctl.size % sizeof(struct eblob_disk_control)) {
-		err = -EBADF;
-		goto err_out_close;
-	}
 
 	err = eblob_index_blocks_fill(bctl);
 	if (err)

--- a/library/range.c
+++ b/library/range.c
@@ -112,7 +112,7 @@ static ssize_t eblob_bsearch_fuzzy(struct eblob_backend *b, struct eblob_base_ct
 
 		eblob_log(b->cfg.log, EBLOB_LOG_NOTICE, "blob: eblob_bsearch_fuzzy: start: %s, end: %s, found: %s, "
 				"pos: %zd, num: %zu, index: %d, fd: %d\n",
-				eblob_dump_id(start->id), eblob_dump_id(end->id), found_id, found, num, bctl->index, bctl->data_fd);
+				eblob_dump_id(start->id), eblob_dump_id(end->id), found_id, found, num, bctl->index, bctl->data_ctl.fd);
 	}
 
 	return found;
@@ -192,7 +192,7 @@ static int eblob_read_range_on_disk(struct eblob_range_request *req)
 				break;
 
 			if (!(dc.flags & BLOB_DISK_CTL_REMOVE)) {
-				err = eblob_range_callback(req, &dc.key, bctl->data_fd,
+				err = eblob_range_callback(req, &dc.key, bctl->data_ctl.fd,
 						dc.position + sizeof(struct eblob_disk_control), dc.data_size);
 				if (err)
 					goto err_out_exit;
@@ -207,7 +207,7 @@ static int eblob_read_range_on_disk(struct eblob_range_request *req)
 				break;
 
 			if (!(dc.flags & BLOB_DISK_CTL_REMOVE)) {
-				err = eblob_range_callback(req, &dc.key, bctl->data_fd,
+				err = eblob_range_callback(req, &dc.key, bctl->data_ctl.fd,
 						dc.position + sizeof(struct eblob_disk_control), dc.data_size);
 				if (err)
 					goto err_out_exit;
@@ -305,7 +305,7 @@ int eblob_read_range(struct eblob_range_request *req)
 						continue;
 				}
 
-				err = eblob_range_callback(req, &e->key, ctl->bctl->data_fd,
+				err = eblob_range_callback(req, &e->key, ctl->bctl->data_ctl.fd,
 						ctl->data_offset + sizeof(struct eblob_disk_control), ctl->size);
 				if (err > 0)
 					goto err_out_unlock;


### PR DESCRIPTION
Changes:
1. .index file removed after index sort.
2. eblob_base_ctl struct refactoring: pack eblob_base_ctl data_{fd, offset, size} fields into data_ctl field.
3. removed extra sorted_index write & flush (before binlog apply).