### PR TITLE
Fix

### DIFF
--- a/doc/blob_format.qdoc
+++ b/doc/blob_format.qdoc
@@ -4,10 +4,11 @@ Eblob is an append-only low-level IO library that stores data in blob files. Eac
 Blob file has the name "{config.file}-0.{blob number}" where {config.file} is the path specified in eblob config and
 {blob number} is an incremental index of the blob. Blob file stores entries with user data.
 Index file has the name "{config.file}-0.{blob_number}.index" and stores only headers of entries from corresponding blob.
-Index sort process adds new sorted index file with name "{config.file}-0.{blob_number}.index.sorted".
+Index sort process sorts index file and save it into "{config.file}-0.{blob_number}.index.sorted" file
+and removes original index file.
 Data sort process sorts blob and index files, saves sorted index into "{config.file}-0.{blob_number}.index.sorted" file,
-makes "{config.file}-0.{blob_number}.index" hardlink to the sorted index file and creates empty "{config.file}-0.{blob_number}.data_is_sorted" file.
-If blob has sorted and unsorted index files eblob will use sorted one.
+sorted blob into "{config.file}-0.{blob number}" file and creates empty "{config.file}-0.{blob_number}.data_is_sorted" file.
+If blob has sorted and unsorted index files eblob will use sorted one and will remove unsorted one.
 
 \section index_file_format Index file format
 

--- a/example/statistics.qdoc
+++ b/example/statistics.qdoc
@@ -89,13 +89,13 @@ Json of eblob internal statistics has follow schema:
 			"description": "total number of removed records in all blobs",
 			"type": "integer" },
 		"records_removed_size": {
-			"description": "total size of all removed records in all blobs",
+			"description": "total size occupied by all removed records in all blobs and index files",
 			"type": "integer" },
 		"records_corrupted": {
 			"description": "total number of corrupted records in all blobs",
 			"type": "integer" },
 		"base_size": {
-			"description": "total size of all blobs",
+			"description": "total size of all blobs and index files",
 			"type": "integer" },
 		"memory_bloom_filter": {
 			"description": "total size of all in-memory bloom filter for all blobs",
@@ -122,13 +122,13 @@ Json of eblob internal statistics has follow schema:
 				"description": "number of removed records in the blob",
 				"type": "number" },
 			"records_removed_size": {
-				"description": "size of all removed records in the blob",
+				"description": "size occupied by all removed records in the blob and the index file",
 				"type": "number" },
 			"records_corrupted": {
 				"description": "number of corrupted records in the blob",
 				"type": "number" },
 			"base_size": {
-				"description": "size of the blob",
+				"description": "size of the blob and the index",
 				"type": "number" },
 			"memory_bloom_filter": {
 				"description": "size of in-memory bloom filter for the blob",
@@ -371,8 +371,8 @@ The stat file has follow structure:
 `
 GLOBAL:					// Global eblob instance statistics
 datasort_start_time: 0			// Unix timestamp of the last defragmentation start
-read_copy_updates: 0			// number of successed data copying from old place to new
-prepare_reused: 0			// number of prepares which was succeded by using current place
+read_copy_updates: 0			// number of succeeded data copying from old place to new
+prepare_reused: 0			// number of prepares which was succeeded by using current place
 memory_index_tree: 34344		// size of in-memory index tree
 lookup_reads_number: 0			// number of lookups for @fd, @offset and @size by key
 data_reads_number: 0			// number of data reads made by eblob
@@ -381,25 +381,25 @@ reads_size: 0				// total size of read data made by eblob
 writes_size: 0				// total size of written data
 index_files_reads_number: 0		// number of index files that was processed by eblob while looking up records "on-disk".
 datasort_completion_time: 0		// end timestamp of the last defragmentation
-datasort_completion_status: 0		// status of last deframentation
+datasort_completion_status: 0		// status of last defragmentation
 
 SUMMARY:				// summary statistics for all blobs
 records_total: 989			// total number of records in all blobs both real and removed
 records_removed: 0			// total number of removed records in all blobs
-records_removed_size: 0			// total size of all removed records in all blobs
+records_removed_size: 0			// total size occupied by all removed records in all blobs and index files
 records_corrupted: 0			// total number of corrupted records in all blobs
-base_size: 103075342808			// total size of all blobs
+base_size: 103075342808			// total size of all blobs and index files
 memory_bloom_filter: 8320		// total size of all in-memory bloom filter for all blobs
 memory_index_blocks: 1872		// total size of all in-memory index blocks for all blobs
-want_defrag: 0				// summ of "want_defrag" of all blobs
+want_defrag: 0				// sum of "want_defrag" of all blobs
 is_sorted: 1				// number of sorted blobs
 
 BASE: data-0.[0-9]*			// one blob statistics
 records_total: 512			// number of records in the blob
 records_removed: 0			// number of removed records in the blob
-records_removed_size: 0			// size of all removed records in the blob
+records_removed_size: 0			// size occupied by all removed records in the blob and in the index file
 records_corrupted: 0			// number of corrupted records in the blob
-base_size: 53687250944			// size of the blob
+base_size: 53687250944			// size of the blob and the index file
 memory_bloom_filter: 8320		// size of in-memory bloom filter for the blob
 memory_index_blocks: 1872		// size of all in-memory index block for the blob
 want_defrag: 0				// the blob defragmentation status possible statuses can be found in \a eblob_defrag_type from blob.h

--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -233,8 +233,9 @@ struct eblob_disk_control {
 	 */
 	uint64_t		data_size;
 
-	/* total size this record occupies on disk.
+	/* total size this record occupies in the blob file.
 	 * It includes alignment and header/footer sizes.
+	 * It doesn't include size of this record's header in the index file.
 	 * This structure is header.
 	 */
 	uint64_t		disk_size;
@@ -466,7 +467,7 @@ struct eblob_iterate_callbacks {
 
 /**
  * Structure which controls which keys should be iterated over.
- * [start, stop] keys are inclusive. 
+ * [start, stop] keys are inclusive.
  */
 
 struct eblob_index_block {
@@ -716,9 +717,11 @@ enum eblob_stat_local_flavour {
 	EBLOB_LST_MIN,
 	EBLOB_LST_RECORDS_TOTAL,
 	EBLOB_LST_RECORDS_REMOVED,
-	EBLOB_LST_REMOVED_SIZE,
+	EBLOB_LST_REMOVED_SIZE,		/* total size occupied by all removed records
+					 * in all blobs and index files
+					 */
 	EBLOB_LST_INDEX_CORRUPTED_ENTRIES,
-	EBLOB_LST_BASE_SIZE,
+	EBLOB_LST_BASE_SIZE,		/* total size of all blobs and index files */
 	EBLOB_LST_BLOOM_SIZE,
 	EBLOB_LST_INDEX_BLOCKS_SIZE,
 	EBLOB_LST_WANT_DEFRAG,

--- a/library/blob.c
+++ b/library/blob.c
@@ -2226,7 +2226,7 @@ static int eblob_plain_writev_prepare(struct eblob_backend *b, struct eblob_key 
 		goto err_out_cleanup_wc;
 	}
 
-	wc->flags = eblob_validate_ctl_flags(b, flags);
+	wc->flags = eblob_validate_ctl_flags(b, flags) | BLOB_DISK_CTL_UNCOMMITTED;
 
 	/*
 	 * We can only overwrite keys inplace if data-sort is not processing

--- a/library/blob.c
+++ b/library/blob.c
@@ -1034,6 +1034,15 @@ static int eblob_mark_entry_removed(struct eblob_backend *b,
 		goto err;
 	}
 
+	/* Sanity: Check that on-disk and in-memory keys are the same */
+	if (memcmp(&old_dc.key, key, sizeof(key)) != 0) {
+		EBLOB_WARNX(b->cfg.log, EBLOB_LOG_ERROR, "keys mismatch: in-memory: %s, on-disk: %s",
+				eblob_dump_id_len(key->id, EBLOB_ID_SIZE),
+				eblob_dump_id_len(old_dc.key.id, EBLOB_ID_SIZE));
+		err = -EINVAL;
+		goto err;
+	}
+
 	eblob_convert_disk_control(&old_dc);
 	/* size of the place occupied by the record in the index and the blob */
 	record_size = old_dc.disk_size + sizeof(struct eblob_disk_control);

--- a/library/index.c
+++ b/library/index.c
@@ -301,7 +301,8 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 
 			if (dc.flags & eblob_bswap64(BLOB_DISK_CTL_REMOVE)) {
 				removed++;
-				removed_size += dc.disk_size;
+				/* size of the place occupied by the record in the index and the blob */
+				removed_size += dc.disk_size + sizeof(struct eblob_disk_control);
 			} else {
 				eblob_bloom_set(bctl, &dc.key);
 			}


### PR DESCRIPTION
Fixed removed records size calculation - now it includes correct size from indexes and blobs.
Added sanity check to `eblob_mark_entry_remove` - it checks that on-disk and in-memory keys are the same.